### PR TITLE
Allow underscores in workplace name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unpublished Version / DEV]
 
+Improve regex to allow the full set of allowable org and workspace names.
+
 ## [[0.1.0](https://github.com/seqeralabs/nf-aggregate/releases/tag/0.1.0)] - 2023-12-13
 
 Initial release of seqeralabs/nf-aggregate, created as a subset of the [nf-core](https://nf-co.re/) template.

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -14,7 +14,7 @@
             },
             "workspace": {
                 "type": "string",
-                "pattern": "^[a-z_]+/[a-z_]+$",
+                "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){1,38}/[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){1,38}$",
                 "errorMessage": "Please provide a valid Seqera Platform Workspace name"
             }
         },

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -14,7 +14,7 @@
             },
             "workspace": {
                 "type": "string",
-                "pattern": "^[a-z]+/[a-z]+$",
+                "pattern": "^[a-z_]+/[a-z_]+$",
                 "errorMessage": "Please provide a valid Seqera Platform Workspace name"
             }
         },

--- a/modules/local/seqera_runs_dump/functions.nf
+++ b/modules/local/seqera_runs_dump/functions.nf
@@ -1,5 +1,5 @@
 
-@Grab('com.github.groovy-wslite:groovy-wslite:1.1.2')
+@Grab('com.github.groovy-wslite:groovy-wslite:1.1.2;transitive=false')
 import wslite.rest.RESTClient
 
 Long getWorkspaceId(orgName, workspaceName, client, authHeader) {

--- a/modules/local/seqera_runs_dump/tests/main.nf.test.snap
+++ b/modules/local/seqera_runs_dump/tests/main.nf.test.snap
@@ -2,14 +2,18 @@
     "Should run without failures": {
         "content": [
             [
-                "service-info.json:md5,0a2624c21efb65b85e37fa3d07903dcc",
+                "service-info.json:md5,8e4874e8eb9e8b84e13bbb22d1e644a9",
                 "workflow-load.json:md5,4f02d5a24ab89aa648cd4346785c8f2c",
                 "workflow-metrics.json:md5,70dd1af37145c8c2d23836fe850622e7",
                 "workflow-tasks.json:md5,577a7472816b7729012a9291d97ff150",
-                "workflow.json:md5,34db0e39f0246670eac77c7a5e9093c9"
+                "workflow.json:md5,658701f8d7af1b7112534a7f58cd9aa7"
             ],
             null
         ],
-        "timestamp": "2023-11-29T13:34:09.5038157"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-29T21:17:42.262920662"
     }
 }


### PR DESCRIPTION
The existing pattern assumes that all org and workspace identifiers are `a-z` (no capital letters, underscores, numbers or dashes).

This PR adjusts the pattern to fix the pattern to match the one used by Seqera Platform - identifiers must begin and end with `[a-zA-Z0-9]` but can otherwise contain (up to 38 chars of) letters lowercase, letters uppercase, numbers, dashes or underscores (`[a-zA-Z0-9]|[-_]`).