### PR TITLE
fix: remove escape from tower env var

### DIFF
--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -22,7 +22,7 @@ process SEQERA_RUNS_DUMP {
     tw \\
         $args \\
         --url=${api_endpoint} \\
-        --access-token=\$TOWER_ACCESS_TOKEN \\
+        --access-token=$TOWER_ACCESS_TOKEN \\
         runs \\
         dump \\
         -id=${meta.id} \\


### PR DESCRIPTION
Fixes the following error when running on GCP:
```
Command error:
  /mnt/disks/nf-tower-test-eu-1/scratch/2CqabFbg1cVUxD/14/2844a1e3d4392d478f740b92d2f367/.command.sh: line 4: TOWER_ACCESS_TOKEN: unbound variable
```

When we escape the `TOWER_ACCESS_TOKEN` variable with `\`, Google Batch interprets that as a literal string instead of performing variable substitution and craps out. Removal of this results in a successful run as we are able to authenticate, but Batch performs variable expansion during script execution before logging occurs so the token is shown in the logs.

Probably not the best practice but I am not sure of how to workaround this. Any ideas? 