### PR TITLE
Remove special chars from version

### DIFF
--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -38,7 +38,7 @@ process SEQERA_RUNS_DUMP {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        seqera-cli: \$(echo \$(tw --version 2>&1) | sed 's/^.*Tower CLI version //; s/ *\$//')
+        seqera-cli: $(echo $(tw --version 2>&1) | sed -e 's/^.*Tower CLI version //' -e 's/ *$//' -e 's/\x1b\[[0-9;]*m//g')
     END_VERSIONS
     """
 }

--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -38,7 +38,7 @@ process SEQERA_RUNS_DUMP {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        seqera-cli: \$(echo \$(tw --version 2>&1) | sed 's/^.*Tower CLI version //; s/ *\$//')
+        seqera-cli: \$(echo \$(NO_COLOR=true tw --version 2>&1) | sed 's/^.*Tower CLI version //; s/ *\$//')
     END_VERSIONS
     """
 }

--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -38,7 +38,7 @@ process SEQERA_RUNS_DUMP {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        seqera-cli: $(echo $(tw --version 2>&1) | sed -e 's/^.*Tower CLI version //' -e 's/ *$//' -e 's/\x1b\[[0-9;]*m//g')
+        seqera-cli: \$(echo \$(tw --version 2>&1) | sed 's/^.*Tower CLI version //; s/ *\$//')
     END_VERSIONS
     """
 }

--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -38,7 +38,7 @@ process SEQERA_RUNS_DUMP {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        seqera-cli: \$(echo \$(tw --version 2>&1) | sed -e 's/^.*Tower CLI version //' -e 's/ *\$//' -e 's/\\x1b\\[[0-9;]*m//g')
+        seqera-cli: $(echo $(tw --version 2>&1) | sed -e 's/^.*Tower CLI version //' -e 's/ *$//' -e 's/\x1b\[[0-9;]*m//g')
     END_VERSIONS
     """
 }

--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -38,7 +38,7 @@ process SEQERA_RUNS_DUMP {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        seqera-cli: $(echo $(tw --version 2>&1) | sed -e 's/^.*Tower CLI version //' -e 's/ *$//' -e 's/\x1b\[[0-9;]*m//g')
+        seqera-cli: \$(echo \$(tw --version 2>&1) | sed -e 's/^.*Tower CLI version //' -e 's/ *\$//' -e 's/\\x1b\\[[0-9;]*m//g')
     END_VERSIONS
     """
 }


### PR DESCRIPTION
`tw --version` outputs some strange characters when using Mamba so you end up with:

```
^[[33mTower CLI version 0.9.2 (build 39a2ec6)^[[39m^[[0m
```

~~The version output in this module failed to exclude the trailing ones, which I've done here.~~

~~We should probably also figure out why these chars are there at all.~~

Fixes https://github.com/seqeralabs/nf-aggregate/issues/25

This is [down to terminal colors](https://github.com/seqeralabs/tower-cli/issues/404#issuecomment-2089866449) (thanks to @jordeu !). So a neater solution is just to turn those off.