### PR TITLE
Bump images for singularity

### DIFF
--- a/modules/local/plot_run_gantt/main.nf
+++ b/modules/local/plot_run_gantt/main.nf
@@ -1,7 +1,7 @@
 process PLOT_RUN_GANTT {
     tag "$meta.id"
     conda 'click=8.0.1 pandas=1.1.5 plotly_express=0.4.1 typing=3.10.0.0'
-    container 'seqeralabs/nf-aggregate:click-8.0.1_pandas-1.1.5_plotly_express-0.4.1_typing-3.10.0.0--342dabfe6548a051'
+    container 'seqeralabs/nf-aggregate:click-8.0.1_pandas-1.1.5_plotly_express-0.4.1_typing-3.10.0.0--ccea219dc6c3d6a1'
 
     input:
     tuple val(meta), path(run_dump)

--- a/modules/local/plot_run_gantt/main.nf
+++ b/modules/local/plot_run_gantt/main.nf
@@ -1,5 +1,6 @@
 process PLOT_RUN_GANTT {
     tag "$meta.id"
+
     conda 'click=8.0.1 pandas=1.1.5 plotly_express=0.4.1 typing=3.10.0.0'
     container 'seqeralabs/nf-aggregate:click-8.0.1_pandas-1.1.5_plotly_express-0.4.1_typing-3.10.0.0--ccea219dc6c3d6a1'
 

--- a/workflows/nf_aggregate/tests/main.nf.test.snap
+++ b/workflows/nf_aggregate/tests/main.nf.test.snap
@@ -1,30 +1,15 @@
 {
-    "Parameters: default": {
-        "content": [
-            {
-                "0": [
-                    
-                ],
-                "1": [
-                    
-                ],
-                "multiqc_report": [
-                    
-                ],
-                "versions": [
-                    
-                ]
-            }
-        ],
-        "timestamp": "2023-12-04T10:38:26.10265603"
-    },
     "Should run without failures": {
         "content": [
             [
-                "versions.yml:md5,43372d67fa3f029a02cc64a571d88e13",
+                "versions.yml:md5,8ab950fb3e4c32ce4745551fa9a4b8e7",
                 "versions.yml:md5,f3cf523314479fcfc842e81116af8ab4"
             ]
         ],
-        "timestamp": "2023-12-04T15:47:00.36029546"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-02T13:45:38.806631609"
     }
 }


### PR DESCRIPTION
The mechanism for dealing appropriately with PATH in Singularity w/ Conda + Wave is newer than the currently used image for the GANTT process (see [Slack](https://seqera.slack.com/archives/C037FCALBDL/p1714623534185549?thread_ts=1714578516.248249&cid=C037FCALBDL)). Bumping this image resolves the issue. 