### PR TITLE
Update API URI

### DIFF
--- a/modules/local/seqera_runs_dump/tests/main.nf.test.snap
+++ b/modules/local/seqera_runs_dump/tests/main.nf.test.snap
@@ -2,7 +2,7 @@
     "Should run without failures": {
         "content": [
             [
-                "service-info.json:md5,8e4874e8eb9e8b84e13bbb22d1e644a9",
+                "service-info.json:md5,bde386e17dda93cdd79a9320d5885aa3",
                 "workflow-load.json:md5,4f02d5a24ab89aa648cd4346785c8f2c",
                 "workflow-metadata.json:md5,b37b4faeddf283a2c44cbe4000e4ab6e",
                 "workflow-metrics.json:md5,13a5b5d7447fad4a8baa053d1abf85e5",
@@ -15,6 +15,6 @@
             "nf-test": "0.8.4",
             "nextflow": "23.10.1"
         },
-        "timestamp": "2024-05-01T10:26:02.841222889"
+        "timestamp": "2024-05-07T14:10:25.921838023"
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,7 @@ params {
     skip_run_gantt             = false
 
     // Seqera CLI options
-    seqera_api_endpoint        = "https://api.tower.nf"
+    seqera_api_endpoint        = "https://api.cloud.seqera.io"
     seqera_cli_extra_args      = null
 
     // MultiQC options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -39,7 +39,7 @@
             "properties": {
                 "seqera_api_endpoint": {
                     "type": "string",
-                    "default": "https://api.tower.nf",
+                    "default": "https://api.cloud.seqera.io",
                     "description": "Seqera Platform API endpoint URL.",
                     "fa_icon": "fas fa-question-circle"
                 },


### PR DESCRIPTION
We get errors running in Seqera platform when using the old 'tower' API URI:

```
[0;31mThe following invalid input values have been detected:
* --input: the file or directory 'https://api.cloud.seqera.io/workspaces/162690105070735/datasets/3IsL8QHGMIRMQFO1LDXLig/v/1/n/samplesheet_nf-aggregate.csv' does not exist.
[0m
 -- Check script '.nextflow/assets/seqeralabs/nf-aggregate/./workflows/nf_aggregate/../../subworkflows/local/utils_nf_aggregate/../../nf-core/utils_nfvalidation_plugin/main.nf' at line: 55 or see 'nf-2atrw11Mi4s56h.log' file for more details
```

Switching to `api.cloud.seqera.io` makes things work.