### PR TITLE
Remove docker.userEmulation

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -94,7 +94,6 @@ profiles {
     }
     docker {
         docker.enabled         = true
-        docker.userEmulation   = true
         conda.enabled          = false
         singularity.enabled    = false
         podman.enabled         = false


### PR DESCRIPTION
> WARN: Undocumented setting `docker.userEmulation` is not supported any more - please remove it from your config

This PR removes this unused option.