### PR TITLE
Seqera containers: POC 2

### DIFF
--- a/modules/local/plot_run_gantt/main.nf
+++ b/modules/local/plot_run_gantt/main.nf
@@ -2,7 +2,6 @@ process PLOT_RUN_GANTT {
     tag "$meta.id"
 
     conda 'click=8.0.1 pandas=1.1.5 plotly_express=0.4.1 typing=3.10.0.0'
-    container 'seqeralabs/nf-aggregate:click-8.0.1_pandas-1.1.5_plotly_express-0.4.1_typing-3.10.0.0--ccea219dc6c3d6a1'
 
     input:
     tuple val(meta), path(run_dump)

--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -3,7 +3,6 @@ include { getRunMetadata } from './functions'
 process SEQERA_RUNS_DUMP {
     tag "$meta.id"
     conda 'tower-cli=0.9.2'
-    container 'seqeralabs/nf-aggregate:tower-cli-0.9.2--hdfd78af_1'
 
     input:
     val meta

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -2,9 +2,6 @@ process MULTIQC {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.21--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.21--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"

--- a/nextflow.config
+++ b/nextflow.config
@@ -64,13 +64,10 @@ profiles {
         cleanup                = false
         nextflow.enable.configProcessNamesValidation = true
     }
-    wave {
-        apptainer.ociAutoPull   = true
-        singularity.ociAutoPull = true
-        wave.build.repository   = 'quay.io/seqeralabs/nf-aggregate'
+    seqera_containers {
         wave.enabled            = true
         wave.freeze             = true
-        wave.strategy           = ['conda', 'container', 'dockerfile', 'spack']
+        wave.strategy           = ['conda']
     }
     conda {
         conda.enabled           = true
@@ -103,7 +100,7 @@ profiles {
         docker.runOptions       = '-u $(id -u):$(id -g)'
     }
     arm {
-        docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64'
+        process.arch            = 'linux/arm64'
     }
     singularity {
         singularity.enabled     = true


### PR DESCRIPTION
# Seqera Containers: Proof of concept No. 2

## Generate containers at user-download

Workflow for generating:

* Nothing. Container is stripped from pipeline, so just update conda.

Workflow for usage:

* Online
    * Use `nextflow run -profile seqera_containers` (`-profile seqera_containers,singularity`, `-profile seqera_containers,singularity,arm` etc)
* Offline
    * Download process (could be bundled into a single command at later date). Something like:
        ```bash
        nf-core download seqeralabs/nf-aggregate
        nextflow inspect . -concretize -profile test,seqera_containers,singularity > containers.json
        jq -r '.processes[].container' containers.json | sort | uniq > containers.txt
        while IFS= read -r line; do singularity pull "$line"; done < "$1"
        ```
    * Generate a local config file to tell Nextflow where to find the Singularity image files. eg:
         ```bash
        nextflow inspect . -concretize -profile test,seqera_containers,singularity -format config > containers.config
        # Manually switch out base file path with downloaded filenames, I guess?
        ```
    * Would need documentation and ideally addition to the `nf-core download` command.