### PR TITLE
Seqera containers: POC 3

### DIFF
--- a/modules/local/plot_run_gantt/main.nf
+++ b/modules/local/plot_run_gantt/main.nf
@@ -2,7 +2,6 @@ process PLOT_RUN_GANTT {
     tag "$meta.id"
 
     conda 'click=8.0.1 pandas=1.1.5 plotly_express=0.4.1 typing=3.10.0.0'
-    container 'seqeralabs/nf-aggregate:click-8.0.1_pandas-1.1.5_plotly_express-0.4.1_typing-3.10.0.0--ccea219dc6c3d6a1'
 
     input:
     tuple val(meta), path(run_dump)

--- a/modules/local/plot_run_gantt/main.nf
+++ b/modules/local/plot_run_gantt/main.nf
@@ -1,8 +1,8 @@
 def mod_container = switch([workflow.containerEngine, workflow.profile]) {
-    case {it[0] == 'singularity' &&  it[1].contains('arm')} -> 'oras://community.wave.seqera.io/library/click_pandas_plotly_express_typing:3fe674b9fa7b15b8'
-    case {it[0] == 'singularity'} -> 'oras://community.wave.seqera.io/library/click_pandas_plotly_express_typing:a4af841350996386'
-    case {it[1].contains('arm')} -> 'community.wave.seqera.io/library/click_pandas_plotly_express_typing:2e5e17c7ed2d1115'
-    default -> 'community.wave.seqera.io/library/click_pandas_plotly_express_typing:21adb9e2d1b605a5'
+    case {it[0] == 'singularity' &&  it[1].contains('arm')} -> 'click_pandas_plotly_express_typing:3fe674b9fa7b15b8'
+    case {it[0] == 'singularity'} -> 'click_pandas_plotly_express_typing:a4af841350996386'
+    case {it[1].contains('arm')} -> 'click_pandas_plotly_express_typing:2e5e17c7ed2d1115'
+    default -> 'click_pandas_plotly_express_typing:21adb9e2d1b605a5'
 }
 
 process PLOT_RUN_GANTT {

--- a/modules/local/plot_run_gantt/main.nf
+++ b/modules/local/plot_run_gantt/main.nf
@@ -1,7 +1,15 @@
+def mod_container = switch([workflow.containerEngine, workflow.profile]) {
+    case {it[0] == 'singularity' &&  it[1].contains('arm')} -> 'oras://community.wave.seqera.io/library/click_pandas_plotly_express_typing:3fe674b9fa7b15b8'
+    case {it[0] == 'singularity'} -> 'oras://community.wave.seqera.io/library/click_pandas_plotly_express_typing:a4af841350996386'
+    case {it[1].contains('arm')} -> 'community.wave.seqera.io/library/click_pandas_plotly_express_typing:2e5e17c7ed2d1115'
+    default -> 'community.wave.seqera.io/library/click_pandas_plotly_express_typing:21adb9e2d1b605a5'
+}
+
 process PLOT_RUN_GANTT {
     tag "$meta.id"
 
     conda 'click=8.0.1 pandas=1.1.5 plotly_express=0.4.1 typing=3.10.0.0'
+    container mod_container
 
     input:
     tuple val(meta), path(run_dump)

--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -3,7 +3,6 @@ include { getRunMetadata } from './functions'
 process SEQERA_RUNS_DUMP {
     tag "$meta.id"
     conda 'tower-cli=0.9.2'
-    container 'seqeralabs/nf-aggregate:tower-cli-0.9.2--hdfd78af_1'
 
     input:
     val meta

--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -1,10 +1,10 @@
 include { getRunMetadata } from './functions'
 
 def mod_container = switch([workflow.containerEngine, workflow.profile]) {
-    case {it[0] == 'singularity' &&  it[1].contains('arm')} -> 'oras://community.wave.seqera.io/library/tower-cli:0.9.2--5198075f4b9d6343'
-    case {it[0] == 'singularity'} -> 'oras://community.wave.seqera.io/library/tower-cli:0.9.2--caeb70536524603e'
-    case {it[1].contains('arm')} -> 'community.wave.seqera.io/library/tower-cli:0.9.2--a2fbb3505faf1193'
-    default -> 'community.wave.seqera.io/library/tower-cli:0.9.2--28258d337ec30808'
+    case {it[0] == 'singularity' &&  it[1].contains('arm')} -> 'tower-cli:0.9.2--5198075f4b9d6343'
+    case {it[0] == 'singularity'} -> 'tower-cli:0.9.2--caeb70536524603e'
+    case {it[1].contains('arm')} -> 'tower-cli:0.9.2--a2fbb3505faf1193'
+    default -> 'tower-cli:0.9.2--28258d337ec30808'
 }
 
 process SEQERA_RUNS_DUMP {

--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -1,8 +1,16 @@
 include { getRunMetadata } from './functions'
 
+def mod_container = switch([workflow.containerEngine, workflow.profile]) {
+    case {it[0] == 'singularity' &&  it[1].contains('arm')} -> 'oras://community.wave.seqera.io/library/tower-cli:0.9.2--5198075f4b9d6343'
+    case {it[0] == 'singularity'} -> 'oras://community.wave.seqera.io/library/tower-cli:0.9.2--caeb70536524603e'
+    case {it[1].contains('arm')} -> 'community.wave.seqera.io/library/tower-cli:0.9.2--a2fbb3505faf1193'
+    default -> 'community.wave.seqera.io/library/tower-cli:0.9.2--28258d337ec30808'
+}
+
 process SEQERA_RUNS_DUMP {
     tag "$meta.id"
     conda 'tower-cli=0.9.2'
+    container mod_container
 
     input:
     val meta

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -2,9 +2,6 @@ process MULTIQC {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.21--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.21--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -1,8 +1,8 @@
 def mod_container = switch([workflow.containerEngine, workflow.profile]) {
-    case {it[0] == 'singularity' &&  it[1].contains('arm')} -> 'oras://community.wave.seqera.io/library/multiqc:1.22.1--af20ae77441fdc43'
-    case {it[0] == 'singularity'} -> 'oras://community.wave.seqera.io/library/multiqc:1.22.1--ac0a91c1ae1c160c'
-    case {it[1].contains('arm')} -> 'community.wave.seqera.io/library/multiqc:1.22.1--22ddc3b95632778f'
-    default -> 'community.wave.seqera.io/library/multiqc:1.22.1--4886de6095538010'
+    case {it[0] == 'singularity' &&  it[1].contains('arm')} -> 'multiqc:1.22.1--af20ae77441fdc43'
+    case {it[0] == 'singularity'} -> 'multiqc:1.22.1--ac0a91c1ae1c160c'
+    case {it[1].contains('arm')} -> 'multiqc:1.22.1--22ddc3b95632778f'
+    default -> 'multiqc:1.22.1--4886de6095538010'
 }
 
 process MULTIQC {

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -1,3 +1,10 @@
+def mod_container = switch([workflow.containerEngine, workflow.profile]) {
+    case {it[0] == 'singularity' &&  it[1].contains('arm')} -> 'oras://community.wave.seqera.io/library/multiqc:1.22.1--af20ae77441fdc43'
+    case {it[0] == 'singularity'} -> 'oras://community.wave.seqera.io/library/multiqc:1.22.1--ac0a91c1ae1c160c'
+    case {it[1].contains('arm')} -> 'community.wave.seqera.io/library/multiqc:1.22.1--22ddc3b95632778f'
+    default -> 'community.wave.seqera.io/library/multiqc:1.22.1--4886de6095538010'
+}
+
 process MULTIQC {
     label 'process_single'
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -159,10 +159,10 @@ profiles {
 // Set default registry for Apptainer, Docker, Podman and Singularity independent of -profile
 // Will not be used unless Apptainer / Docker / Podman / Singularity are enabled
 // Set to your registry if you have a mirror of containers
-apptainer.registry   = 'quay.io'
-docker.registry      = 'quay.io'
-podman.registry      = 'quay.io'
-singularity.registry = 'quay.io'
+apptainer.registry   = 'oras://community.wave.seqera.io/library/'
+docker.registry      = 'community.wave.seqera.io/library/'
+podman.registry      = 'community.wave.seqera.io/library/'
+singularity.registry = 'oras://community.wave.seqera.io/library/'
 
 // Nextflow plugins
 plugins {

--- a/nextflow.config
+++ b/nextflow.config
@@ -64,13 +64,10 @@ profiles {
         cleanup                = false
         nextflow.enable.configProcessNamesValidation = true
     }
-    wave {
-        apptainer.ociAutoPull   = true
-        singularity.ociAutoPull = true
-        wave.build.repository   = 'quay.io/seqeralabs/nf-aggregate'
+    seqera_containers {
         wave.enabled            = true
         wave.freeze             = true
-        wave.strategy           = ['conda', 'container', 'dockerfile', 'spack']
+        wave.strategy           = ['conda']
     }
     conda {
         conda.enabled           = true
@@ -103,7 +100,7 @@ profiles {
         docker.runOptions       = '-u $(id -u):$(id -g)'
     }
     arm {
-        docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64'
+        process.arch            = 'linux/arm64'
     }
     singularity {
         singularity.enabled     = true


### PR DESCRIPTION
# Seqera Containers: Proof of concept No. 3

## Hardcode container URIs at module level.

Workflow for generating:

* Keep conda spec in modules up to date
* When something changes, run the Wave CLI to fetch new container URIs and update module files
    * Either with some CI / nf-core tools code. Or using Renovate?
    * [Maybe?] Remove the registry base, as this is set in the pipeline `nextflow.config`

Workflow for usage: (Identical to current usage)

* Online
    * Use `nextflow run -profile docker` or `singularity`, `arm` etc. (profile names up for refinement). Same as current.
* Offline
    * Use `nf-core download` as done currently, no change needed.