### PR TITLE
Seqera containers: POC 4

### DIFF
--- a/modules/local/plot_run_gantt/main.nf
+++ b/modules/local/plot_run_gantt/main.nf
@@ -2,7 +2,6 @@ process PLOT_RUN_GANTT {
     tag "$meta.id"
 
     conda 'click=8.0.1 pandas=1.1.5 plotly_express=0.4.1 typing=3.10.0.0'
-    container 'seqeralabs/nf-aggregate:click-8.0.1_pandas-1.1.5_plotly_express-0.4.1_typing-3.10.0.0--ccea219dc6c3d6a1'
 
     input:
     tuple val(meta), path(run_dump)

--- a/modules/local/plot_run_gantt/nextflow.config
+++ b/modules/local/plot_run_gantt/nextflow.config
@@ -7,3 +7,10 @@ process {
         ]
     }
 }
+
+profiles {
+    docker            { process.withName: 'PLOT_RUN_GANTT' { container = 'community.wave.seqera.io/library/click_pandas_plotly_express_typing:21adb9e2d1b605a5' } }
+    docker_arm64      { process.withName: 'PLOT_RUN_GANTT' { container = 'community.wave.seqera.io/library/click_pandas_plotly_express_typing:2e5e17c7ed2d1115' } }
+    singularity       { process.withName: 'PLOT_RUN_GANTT' { container = 'oras://community.wave.seqera.io/library/click_pandas_plotly_express_typing:a4af841350996386' } }
+    singularity_arm64 { process.withName: 'PLOT_RUN_GANTT' { container = 'oras://community.wave.seqera.io/library/click_pandas_plotly_express_typing:3fe674b9fa7b15b8' } }
+}

--- a/modules/local/plot_run_gantt/nextflow.config
+++ b/modules/local/plot_run_gantt/nextflow.config
@@ -9,8 +9,8 @@ process {
 }
 
 profiles {
-    docker            { process.withName: 'PLOT_RUN_GANTT' { container = 'community.wave.seqera.io/library/click_pandas_plotly_express_typing:21adb9e2d1b605a5' } }
-    docker_arm64      { process.withName: 'PLOT_RUN_GANTT' { container = 'community.wave.seqera.io/library/click_pandas_plotly_express_typing:2e5e17c7ed2d1115' } }
-    singularity       { process.withName: 'PLOT_RUN_GANTT' { container = 'oras://community.wave.seqera.io/library/click_pandas_plotly_express_typing:a4af841350996386' } }
-    singularity_arm64 { process.withName: 'PLOT_RUN_GANTT' { container = 'oras://community.wave.seqera.io/library/click_pandas_plotly_express_typing:3fe674b9fa7b15b8' } }
+    docker            { process.withName: 'PLOT_RUN_GANTT' { container = 'click_pandas_plotly_express_typing:21adb9e2d1b605a5' } }
+    docker_arm64      { process.withName: 'PLOT_RUN_GANTT' { container = 'click_pandas_plotly_express_typing:2e5e17c7ed2d1115' } }
+    singularity       { process.withName: 'PLOT_RUN_GANTT' { container = 'click_pandas_plotly_express_typing:a4af841350996386' } }
+    singularity_arm64 { process.withName: 'PLOT_RUN_GANTT' { container = 'click_pandas_plotly_express_typing:3fe674b9fa7b15b8' } }
 }

--- a/modules/local/plot_run_gantt/nextflow.config
+++ b/modules/local/plot_run_gantt/nextflow.config
@@ -5,11 +5,11 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
+        container = 'click_pandas_plotly_express_typing:21adb9e2d1b605a5' }
     }
 }
 
 profiles {
-    docker            { process.withName: 'PLOT_RUN_GANTT' { container = 'click_pandas_plotly_express_typing:21adb9e2d1b605a5' } }
     docker_arm64      { process.withName: 'PLOT_RUN_GANTT' { container = 'click_pandas_plotly_express_typing:2e5e17c7ed2d1115' } }
     singularity       { process.withName: 'PLOT_RUN_GANTT' { container = 'click_pandas_plotly_express_typing:a4af841350996386' } }
     singularity_arm64 { process.withName: 'PLOT_RUN_GANTT' { container = 'click_pandas_plotly_express_typing:3fe674b9fa7b15b8' } }

--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -3,7 +3,6 @@ include { getRunMetadata } from './functions'
 process SEQERA_RUNS_DUMP {
     tag "$meta.id"
     conda 'tower-cli=0.9.2'
-    container 'seqeralabs/nf-aggregate:tower-cli-0.9.2--hdfd78af_1'
 
     input:
     val meta

--- a/modules/local/seqera_runs_dump/nextflow.config
+++ b/modules/local/seqera_runs_dump/nextflow.config
@@ -11,8 +11,8 @@ process {
 }
 
 profiles {
-    docker            { process.withName: 'SEQERA_RUNS_DUMP' { container = 'community.wave.seqera.io/library/tower-cli:0.9.2--dc544a7e574ab73b' } }
-    docker_arm64      { process.withName: 'SEQERA_RUNS_DUMP' { container = 'community.wave.seqera.io/library/tower-cli:0.9.2--104eab7c00912b48' } }
-    singularity       { process.withName: 'SEQERA_RUNS_DUMP' { container = 'oras://community.wave.seqera.io/library/tower-cli:0.9.2--810270aea7c40770' } }
-    singularity_arm64 { process.withName: 'SEQERA_RUNS_DUMP' { container = 'oras://community.wave.seqera.io/library/tower-cli:0.9.2--23fa648bc78102d6' } }
+    docker            { process.withName: 'SEQERA_RUNS_DUMP' { container = 'tower-cli:0.9.2--dc544a7e574ab73b' } }
+    docker_arm64      { process.withName: 'SEQERA_RUNS_DUMP' { container = 'tower-cli:0.9.2--104eab7c00912b48' } }
+    singularity       { process.withName: 'SEQERA_RUNS_DUMP' { container = 'tower-cli:0.9.2--810270aea7c40770' } }
+    singularity_arm64 { process.withName: 'SEQERA_RUNS_DUMP' { container = 'tower-cli:0.9.2--23fa648bc78102d6' } }
 }

--- a/modules/local/seqera_runs_dump/nextflow.config
+++ b/modules/local/seqera_runs_dump/nextflow.config
@@ -7,11 +7,11 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') || filename.endsWith('.json') ? null : filename }
         ]
+        container = 'tower-cli:0.9.2--dc544a7e574ab73b'
     }
 }
 
 profiles {
-    docker            { process.withName: 'SEQERA_RUNS_DUMP' { container = 'tower-cli:0.9.2--dc544a7e574ab73b' } }
     docker_arm64      { process.withName: 'SEQERA_RUNS_DUMP' { container = 'tower-cli:0.9.2--104eab7c00912b48' } }
     singularity       { process.withName: 'SEQERA_RUNS_DUMP' { container = 'tower-cli:0.9.2--810270aea7c40770' } }
     singularity_arm64 { process.withName: 'SEQERA_RUNS_DUMP' { container = 'tower-cli:0.9.2--23fa648bc78102d6' } }

--- a/modules/local/seqera_runs_dump/nextflow.config
+++ b/modules/local/seqera_runs_dump/nextflow.config
@@ -9,3 +9,10 @@ process {
         ]
     }
 }
+
+profiles {
+    docker            { process.withName: 'SEQERA_RUNS_DUMP' { container = 'community.wave.seqera.io/library/tower-cli:0.9.2--dc544a7e574ab73b' } }
+    docker_arm64      { process.withName: 'SEQERA_RUNS_DUMP' { container = 'community.wave.seqera.io/library/tower-cli:0.9.2--104eab7c00912b48' } }
+    singularity       { process.withName: 'SEQERA_RUNS_DUMP' { container = 'oras://community.wave.seqera.io/library/tower-cli:0.9.2--810270aea7c40770' } }
+    singularity_arm64 { process.withName: 'SEQERA_RUNS_DUMP' { container = 'oras://community.wave.seqera.io/library/tower-cli:0.9.2--23fa648bc78102d6' } }
+}

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -2,9 +2,6 @@ process MULTIQC {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.21--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.21--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"

--- a/modules/nf-core/multiqc/nextflow.config
+++ b/modules/nf-core/multiqc/nextflow.config
@@ -8,3 +8,10 @@ process {
         ]
     }
 }
+
+profiles {
+    docker            { process.withName: 'MULTIQC' { container = 'community.wave.seqera.io/library/multiqc:4b4f4c914c0e39d4' } }
+    docker_arm64      { process.withName: 'MULTIQC' { container = 'community.wave.seqera.io/library/multiqc:3ea3e7cfd06863ea' } }
+    singularity       { process.withName: 'MULTIQC' { container = 'oras://community.wave.seqera.io/library/multiqc:21bd1c393b5aa114' } }
+    singularity_arm64 { process.withName: 'MULTIQC' { container = 'oras://community.wave.seqera.io/library/multiqc:351bc8ad51a0f772' } }
+}

--- a/modules/nf-core/multiqc/nextflow.config
+++ b/modules/nf-core/multiqc/nextflow.config
@@ -10,8 +10,8 @@ process {
 }
 
 profiles {
-    docker            { process.withName: 'MULTIQC' { container = 'community.wave.seqera.io/library/multiqc:4b4f4c914c0e39d4' } }
-    docker_arm64      { process.withName: 'MULTIQC' { container = 'community.wave.seqera.io/library/multiqc:3ea3e7cfd06863ea' } }
-    singularity       { process.withName: 'MULTIQC' { container = 'oras://community.wave.seqera.io/library/multiqc:21bd1c393b5aa114' } }
-    singularity_arm64 { process.withName: 'MULTIQC' { container = 'oras://community.wave.seqera.io/library/multiqc:351bc8ad51a0f772' } }
+    docker            { process.withName: 'MULTIQC' { container = 'multiqc:4b4f4c914c0e39d4' } }
+    docker_arm64      { process.withName: 'MULTIQC' { container = 'multiqc:3ea3e7cfd06863ea' } }
+    singularity       { process.withName: 'MULTIQC' { container = 'multiqc:21bd1c393b5aa114' } }
+    singularity_arm64 { process.withName: 'MULTIQC' { container = 'multiqc:351bc8ad51a0f772' } }
 }

--- a/modules/nf-core/multiqc/nextflow.config
+++ b/modules/nf-core/multiqc/nextflow.config
@@ -6,11 +6,11 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
+        container = 'multiqc:4b4f4c914c0e39d4'
     }
 }
 
 profiles {
-    docker            { process.withName: 'MULTIQC' { container = 'multiqc:4b4f4c914c0e39d4' } }
     docker_arm64      { process.withName: 'MULTIQC' { container = 'multiqc:3ea3e7cfd06863ea' } }
     singularity       { process.withName: 'MULTIQC' { container = 'multiqc:21bd1c393b5aa114' } }
     singularity_arm64 { process.withName: 'MULTIQC' { container = 'multiqc:351bc8ad51a0f772' } }

--- a/nextflow.config
+++ b/nextflow.config
@@ -159,10 +159,10 @@ profiles {
 // Set default registry for Apptainer, Docker, Podman and Singularity independent of -profile
 // Will not be used unless Apptainer / Docker / Podman / Singularity are enabled
 // Set to your registry if you have a mirror of containers
-apptainer.registry   = 'quay.io'
-docker.registry      = 'quay.io'
-podman.registry      = 'quay.io'
-singularity.registry = 'quay.io'
+apptainer.registry   = 'oras://community.wave.seqera.io/library'
+docker.registry      = 'community.wave.seqera.io/library'
+podman.registry      = 'community.wave.seqera.io/library'
+singularity.registry = 'oras://community.wave.seqera.io/library'
 
 // Nextflow plugins
 plugins {

--- a/nextflow.config
+++ b/nextflow.config
@@ -64,13 +64,10 @@ profiles {
         cleanup                = false
         nextflow.enable.configProcessNamesValidation = true
     }
-    wave {
-        apptainer.ociAutoPull   = true
-        singularity.ociAutoPull = true
-        wave.build.repository   = 'quay.io/seqeralabs/nf-aggregate'
+    seqera_containers {
         wave.enabled            = true
         wave.freeze             = true
-        wave.strategy           = ['conda', 'container', 'dockerfile', 'spack']
+        wave.strategy           = ['conda']
     }
     conda {
         conda.enabled           = true
@@ -103,7 +100,7 @@ profiles {
         docker.runOptions       = '-u $(id -u):$(id -g)'
     }
     arm {
-        docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64'
+        process.arch            = 'linux/arm64'
     }
     singularity {
         singularity.enabled     = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -99,10 +99,30 @@ profiles {
         apptainer.enabled       = false
         docker.runOptions       = '-u $(id -u):$(id -g)'
     }
+    docker_arm64 { // Identical to above, but used by Seqera Containers config files at module level
+        docker.enabled          = true
+        conda.enabled           = false
+        singularity.enabled     = false
+        podman.enabled          = false
+        shifter.enabled         = false
+        charliecloud.enabled    = false
+        apptainer.enabled       = false
+        docker.runOptions       = '-u $(id -u):$(id -g)'
+    }
     arm {
         process.arch            = 'linux/arm64'
     }
     singularity {
+        singularity.enabled     = true
+        singularity.autoMounts  = true
+        conda.enabled           = false
+        docker.enabled          = false
+        podman.enabled          = false
+        shifter.enabled         = false
+        charliecloud.enabled    = false
+        apptainer.enabled       = false
+    }
+    singularity_arm64 { // Identical to above, but used by Seqera Containers config files at module level
         singularity.enabled     = true
         singularity.autoMounts  = true
         conda.enabled           = false


### PR DESCRIPTION
# Seqera Containers: Proof of concept No. 4

## Hardcode container URIs at module level - in a config file

> [!NOTE]
> Only works here because this pipeline is already importing the module-level `nextflow.config` files here:
> https://github.com/seqeralabs/nf-aggregate/blob/496dba5f299a39103e0bc44cbab189ac1d498b22/workflows/nf_aggregate/nextflow.config#L1-L3
> Flow is as follows:
> 1. `nextflow.config`
> 1. _imports_ `workflows/nf_aggregate/nextflow.config`
> 1. _imports_ `modules/***/***/nextflow.config`

Workflow for generating:

* Keep conda spec in modules up to date
* When updating modules _in the modules repo_ run `nextflow inspect` commands to regenerate module-level config files with pinned container names
* When adding a shared module to an nf-core pipeline, automatically add `includeConfig` statements for module-level config file.

Workflow for usage: (same as current except different profile names)

* Online
    * Use `nextflow run -profile docker` or `docker,docker_arm`, `singularity,singularity_arm`
* Offline
    * Use `nf-core download` as done currently, _may_ need some kind of profile change, not sure.

Put the config into separated files at module level to keep them out of the way.

* Similar to https://github.com/seqeralabs/nf-aggregate/pull/43 except module level, not pipeline level
* Similar to https://github.com/seqeralabs/nf-aggregate/pull/45 except in a separate config file, not `main.nf`