### PR TITLE
Seqera containers: POC 5

### DIFF
--- a/modules/local/plot_run_gantt/main.nf
+++ b/modules/local/plot_run_gantt/main.nf
@@ -2,7 +2,6 @@ process PLOT_RUN_GANTT {
     tag "$meta.id"
 
     conda 'click=8.0.1 pandas=1.1.5 plotly_express=0.4.1 typing=3.10.0.0'
-    container 'seqeralabs/nf-aggregate:click-8.0.1_pandas-1.1.5_plotly_express-0.4.1_typing-3.10.0.0--ccea219dc6c3d6a1'
 
     input:
     tuple val(meta), path(run_dump)

--- a/modules/local/plot_run_gantt/nextflow.config
+++ b/modules/local/plot_run_gantt/nextflow.config
@@ -7,3 +7,10 @@ process {
         ]
     }
 }
+
+profiles {
+    docker            { process.withName: 'PLOT_RUN_GANTT' { container = 'community.wave.seqera.io/library/click_pandas_plotly_express_typing:21adb9e2d1b605a5' } }
+    docker_arm64      { process.withName: 'PLOT_RUN_GANTT' { container = 'community.wave.seqera.io/library/click_pandas_plotly_express_typing:2e5e17c7ed2d1115' } }
+    singularity       { process.withName: 'PLOT_RUN_GANTT' { container = 'oras://community.wave.seqera.io/library/click_pandas_plotly_express_typing:a4af841350996386' } }
+    singularity_arm64 { process.withName: 'PLOT_RUN_GANTT' { container = 'oras://community.wave.seqera.io/library/click_pandas_plotly_express_typing:3fe674b9fa7b15b8' } }
+}

--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -3,7 +3,6 @@ include { getRunMetadata } from './functions'
 process SEQERA_RUNS_DUMP {
     tag "$meta.id"
     conda 'tower-cli=0.9.2'
-    container 'seqeralabs/nf-aggregate:tower-cli-0.9.2--hdfd78af_1'
 
     input:
     val meta

--- a/modules/local/seqera_runs_dump/nextflow.config
+++ b/modules/local/seqera_runs_dump/nextflow.config
@@ -9,3 +9,10 @@ process {
         ]
     }
 }
+
+profiles {
+    docker            { process.withName: 'SEQERA_RUNS_DUMP' { container = 'community.wave.seqera.io/library/tower-cli:0.9.2--dc544a7e574ab73b' } }
+    docker_arm64      { process.withName: 'SEQERA_RUNS_DUMP' { container = 'community.wave.seqera.io/library/tower-cli:0.9.2--104eab7c00912b48' } }
+    singularity       { process.withName: 'SEQERA_RUNS_DUMP' { container = 'oras://community.wave.seqera.io/library/tower-cli:0.9.2--810270aea7c40770' } }
+    singularity_arm64 { process.withName: 'SEQERA_RUNS_DUMP' { container = 'oras://community.wave.seqera.io/library/tower-cli:0.9.2--23fa648bc78102d6' } }
+}

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -2,9 +2,6 @@ process MULTIQC {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.21--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.21--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"

--- a/modules/nf-core/multiqc/nextflow.config
+++ b/modules/nf-core/multiqc/nextflow.config
@@ -8,3 +8,10 @@ process {
         ]
     }
 }
+
+profiles {
+    docker            { process.withName: 'MULTIQC' { container = 'community.wave.seqera.io/library/multiqc:4b4f4c914c0e39d4' } }
+    docker_arm64      { process.withName: 'MULTIQC' { container = 'community.wave.seqera.io/library/multiqc:3ea3e7cfd06863ea' } }
+    singularity       { process.withName: 'MULTIQC' { container = 'oras://community.wave.seqera.io/library/multiqc:21bd1c393b5aa114' } }
+    singularity_arm64 { process.withName: 'MULTIQC' { container = 'oras://community.wave.seqera.io/library/multiqc:351bc8ad51a0f772' } }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -181,9 +181,6 @@ env {
     TOWER_ACCESS_TOKEN = "$TOWER_ACCESS_TOKEN"
 }
 
-// Load Nextflow config for nf_aggregate workflow
-includeConfig 'workflows/nf_aggregate/nextflow.config'
-
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -64,13 +64,10 @@ profiles {
         cleanup                = false
         nextflow.enable.configProcessNamesValidation = true
     }
-    wave {
-        apptainer.ociAutoPull   = true
-        singularity.ociAutoPull = true
-        wave.build.repository   = 'quay.io/seqeralabs/nf-aggregate'
+    seqera_containers {
         wave.enabled            = true
         wave.freeze             = true
-        wave.strategy           = ['conda', 'container', 'dockerfile', 'spack']
+        wave.strategy           = ['conda']
     }
     conda {
         conda.enabled           = true
@@ -103,7 +100,7 @@ profiles {
         docker.runOptions       = '-u $(id -u):$(id -g)'
     }
     arm {
-        docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64'
+        process.arch            = 'linux/arm64'
     }
     singularity {
         singularity.enabled     = true

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -3,8 +3,12 @@
 //
 
 include { SEQERA_RUNS_DUMP     } from '../../modules/local/seqera_runs_dump'
+includeConfig '../../modules/local/seqera_runs_dump/nextflow.config'
 include { PLOT_RUN_GANTT       } from '../../modules/local/plot_run_gantt'
+includeConfig '../../modules/local/plot_run_gantt/nextflow.config'
 include { MULTIQC              } from '../../modules/nf-core/multiqc'
+includeConfig '../../modules/nf-core/multiqc/nextflow.config'
+
 include { paramsSummaryMultiqc } from '../../subworkflows/local/utils_nf_aggregate'
 include { getProcessVersions   } from '../../subworkflows/local/utils_nf_aggregate'
 include { getWorkflowVersions  } from '../../subworkflows/local/utils_nf_aggregate'

--- a/workflows/nf_aggregate/nextflow.config
+++ b/workflows/nf_aggregate/nextflow.config
@@ -1,3 +1,0 @@
-includeConfig '../../modules/local/seqera_runs_dump/nextflow.config'
-includeConfig '../../modules/local/plot_run_gantt/nextflow.config'
-includeConfig '../../modules/nf-core/multiqc/nextflow.config'


### PR DESCRIPTION
Same as https://github.com/seqeralabs/nf-aggregate/pull/46 except the `includeConfig` is alongside the `include`, to make automation easier and also make it easier to trace config logic.

👉🏻  See 2499af791c8526c1e4dc3fadb968a2dd001f1bd1 for only differences to #46

@bentsherman / others - will loading the config in the main script instead of `nextflow.config` like this break stuff / do weird things? I feel like it's bad practice, even if the code is easier to read.