### PR TITLE
Fix: Organise results folder structure by pipeline 

### DIFF
--- a/modules/local/seqera_runs_dump/functions.nf
+++ b/modules/local/seqera_runs_dump/functions.nf
@@ -47,8 +47,8 @@ Map getRunMetadata(meta, log, api_endpoint, trustStorePath, trustStorePassword) 
         if (workspaceId) {
             def workflowResponse = client.get(path: "/workflow/${runId}", query: ["workspaceId":workspaceId], headers: authHeader)
             if (workflowResponse.statusCode == 200) {
-                metaMap = workflowResponse?.json?.workflow?.subMap("runName", "workDir", "projectName")
-                config = new ConfigSlurper().parse( workflowResponse?.json?.workflow?.configText )
+                def metaMap = workflowResponse?.json?.workflow?.subMap("runName", "workDir", "projectName")
+                def config = new ConfigSlurper().parse( workflowResponse?.json?.workflow?.configText )
                 metaMap.fusion =  config.fusion.enabled
 
                 return metaMap ?: [:]

--- a/modules/local/seqera_runs_dump/tests/main.nf.test.snap
+++ b/modules/local/seqera_runs_dump/tests/main.nf.test.snap
@@ -2,7 +2,7 @@
     "Should run without failures": {
         "content": [
             [
-                "service-info.json:md5,108f149aafa287bb56d715c0c7ee0359",
+                "service-info.json:md5,72586e82ad2064d1a90008c7956d80d8",
                 "workflow-load.json:md5,4f02d5a24ab89aa648cd4346785c8f2c",
                 "workflow-metadata.json:md5,b37b4faeddf283a2c44cbe4000e4ab6e",
                 "workflow-metrics.json:md5,13a5b5d7447fad4a8baa053d1abf85e5",
@@ -13,8 +13,8 @@
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nextflow": "24.04.2"
         },
-        "timestamp": "2024-05-20T15:32:40.565622058"
+        "timestamp": "2024-07-25T10:21:06.447483"
     }
 }

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -21,7 +21,7 @@ workflow NF_AGGREGATE {
     skip_multiqc              //     val: Skip MultiQC
     java_truststore_path      //     val: Path to java truststore if using private certs
     java_truststore_password  //     val: Password for java truststore if using private certs
-    
+
     main:
 
     ch_versions = Channel.empty()
@@ -30,6 +30,7 @@ workflow NF_AGGREGATE {
     //
     // MODULE: Fetch run information via the Seqera CLI
     //
+
     SEQERA_RUNS_DUMP (
         ids,
         seqera_api_endpoint,


### PR DESCRIPTION
Fixes a minor inconvenience where all results were published under the first pipeline name that came to pass, such as `results/nf-core_sarek/workflowID-rnaseq`, `results/nf-core_sarek/workflowID-viralrecon` 

Tested on a samplesheet:

```
results
├── nf-core_atacseq
├── nf-core_demultiplex
├── nf-core_rnaseq
├── nf-core_sarek
├── nf-core_scrnaseq
└── pipeline_info
```

organises again the output by pipeline. 
