### PR TITLE
Throw exception and terminate workflow in case config can't be read

### DIFF
--- a/modules/local/seqera_runs_dump/functions.nf
+++ b/modules/local/seqera_runs_dump/functions.nf
@@ -1,7 +1,7 @@
 @Grab('com.github.groovy-wslite:groovy-wslite:1.1.2;transitive=false')
 import wslite.rest.RESTClient
 import groovy.json.JsonSlurper
-import  nextflow.exception.ProcessException
+import nextflow.exception.ProcessException
 
 // Set system properties for custom Java trustStore
 def setTrustStore(trustStorePath, trustStorePassword) {
@@ -49,8 +49,6 @@ Map getRunMetadata(meta, log, api_endpoint, trustStorePath, trustStorePassword) 
             def workflowResponse = client.get(path: "/workflow/${runId}", query: ["workspaceId":workspaceId], headers: authHeader)
             if (workflowResponse.statusCode == 200) {
                 metaMap = workflowResponse?.json?.workflow?.subMap("runName", "workDir", "projectName")
-                // log.warn("config: ${workflowResponse?.json?.workflow?.configText}")
-                // TODO: What is different to the viralrecon config
                 config = new ConfigSlurper().parse( workflowResponse?.json?.workflow?.configText )
                 metaMap.fusion =  config.fusion.enabled
 

--- a/modules/local/seqera_runs_dump/functions.nf
+++ b/modules/local/seqera_runs_dump/functions.nf
@@ -48,8 +48,8 @@ Map getRunMetadata(meta, log, api_endpoint, trustStorePath, trustStorePassword) 
         if (workspaceId) {
             def workflowResponse = client.get(path: "/workflow/${runId}", query: ["workspaceId":workspaceId], headers: authHeader)
             if (workflowResponse.statusCode == 200) {
-                metaMap = workflowResponse?.json?.workflow?.subMap("runName", "workDir", "projectName")
-                config = new ConfigSlurper().parse( workflowResponse?.json?.workflow?.configText )
+                def metaMap = workflowResponse?.json?.workflow?.subMap("runName", "workDir", "projectName")
+                def config = new ConfigSlurper().parse( workflowResponse?.json?.workflow?.configText )
                 metaMap.fusion =  config.fusion.enabled
 
                 return metaMap ?: [:]

--- a/modules/local/seqera_runs_dump/functions.nf
+++ b/modules/local/seqera_runs_dump/functions.nf
@@ -60,14 +60,14 @@ Map getRunMetadata(meta, log, api_endpoint, trustStorePath, trustStorePassword) 
         Could not get workflow details for workflow ${runId} in workspace ${meta.workspace}:
             ↳ Status code ${ex.response?.statusCode} returned from request to ${ex.request?.url} (authentication headers excluded)
         """.stripIndent()
-        log.error(ex)
+        log.error "Exception: ${ex.message}", ex
         throw new ProcessException("Failed to get workflow details for workflow ${runId} in workspace ${meta.workspace}", ex)
     } catch (Exception ex) {
         log.warn """
         An error occurred while getting workflow details for workflow ${runId} in workspace ${meta.workspace}:
             ↳ ${ex.message}
         """.stripIndent()
-        log.error(ex)
+        log.error "Exception: ${ex.message}", ex
         throw new ProcessException("Failed to get workflow details for workflow ${runId} in workspace ${meta.workspace}", ex)
 
     }

--- a/modules/local/seqera_runs_dump/functions.nf
+++ b/modules/local/seqera_runs_dump/functions.nf
@@ -60,12 +60,14 @@ Map getRunMetadata(meta, log, api_endpoint, trustStorePath, trustStorePassword) 
         Could not get workflow details for workflow ${runId} in workspace ${meta.workspace}:
             ↳ Status code ${ex.response?.statusCode} returned from request to ${ex.request?.url} (authentication headers excluded)
         """.stripIndent()
+        log.error(ex)
         throw new ProcessException("Failed to get workflow details for workflow ${runId} in workspace ${meta.workspace}", ex)
     } catch (Exception ex) {
         log.warn """
         An error occurred while getting workflow details for workflow ${runId} in workspace ${meta.workspace}:
             ↳ ${ex.message}
         """.stripIndent()
+        log.error(ex)
         throw new ProcessException("Failed to get workflow details for workflow ${runId} in workspace ${meta.workspace}", ex)
 
     }

--- a/modules/local/seqera_runs_dump/tests/main.nf.test.snap
+++ b/modules/local/seqera_runs_dump/tests/main.nf.test.snap
@@ -2,7 +2,7 @@
     "Should run without failures": {
         "content": [
             [
-                "service-info.json:md5,108f149aafa287bb56d715c0c7ee0359",
+                "service-info.json:md5,72586e82ad2064d1a90008c7956d80d8",
                 "workflow-load.json:md5,4f02d5a24ab89aa648cd4346785c8f2c",
                 "workflow-metadata.json:md5,b37b4faeddf283a2c44cbe4000e4ab6e",
                 "workflow-metrics.json:md5,13a5b5d7447fad4a8baa053d1abf85e5",
@@ -13,8 +13,8 @@
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "23.10.1"
+            "nextflow": "24.04.2"
         },
-        "timestamp": "2024-05-20T15:32:40.565622058"
+        "timestamp": "2024-07-25T10:21:06.447483"
     }
 }

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -21,7 +21,7 @@ workflow NF_AGGREGATE {
     skip_multiqc              //     val: Skip MultiQC
     java_truststore_path      //     val: Path to java truststore if using private certs
     java_truststore_password  //     val: Password for java truststore if using private certs
-    
+
     main:
 
     ch_versions = Channel.empty()
@@ -30,6 +30,7 @@ workflow NF_AGGREGATE {
     //
     // MODULE: Fetch run information via the Seqera CLI
     //
+
     SEQERA_RUNS_DUMP (
         ids,
         seqera_api_endpoint,


### PR DESCRIPTION
If the function `metaOut` fails the workflow used to log the error but then hang and not terminate until it runs out of time. Currently, we have observed that the ConfigSlurper occasionally cannot handle some of the returned configs. 

If we throw the error, the workflow fails and does not keep using ressources. In the future we could consider adding an error Strategy to at least get partial results pending the investigation of why sometimes the config parser errors out. 