### PR TITLE
Remove fusion retrieval to circumvent failures with nested config imports

### DIFF
--- a/modules/local/seqera_runs_dump/functions.nf
+++ b/modules/local/seqera_runs_dump/functions.nf
@@ -50,12 +50,6 @@ Map getRunMetadata(meta, log, api_endpoint, trustStorePath, trustStorePassword) 
 
             if (workflowResponse.statusCode == 200) {
                 def metaMap = workflowResponse?.json?.workflow?.subMap("runName", "workDir", "projectName")
-                String searchString = "fusion {\n   enabled = true\n}"
-
-                if(workflowResponse?.json?.workflow.toString().contains(searchString)) {
-                    metaMap.fusion = "true"
-                }
-
                 return metaMap ?: [:]
             }
         }

--- a/modules/local/seqera_runs_dump/main.nf
+++ b/modules/local/seqera_runs_dump/main.nf
@@ -20,9 +20,10 @@ process SEQERA_RUNS_DUMP {
     def args2 = task.ext.args2 ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     metaOut = meta + getRunMetadata(meta, log, api_endpoint, java_truststore_path, java_truststore_password)
-    fusion = metaOut.fusion ? '--add-fusion-logs' : ''
+    fusion = '' //metaOut.fusion ? '--add-fusion-logs' : '' see issue: https://github.com/seqeralabs/nf-aggregate/issues/55
     javaTrustStore = java_truststore_path ? "-Djavax.net.ssl.trustStore=${java_truststore_path}" : ''
     javaTrustStorePassword = java_truststore_password ? "-Djavax.net.ssl.trustStorePassword=${java_truststore_password}" : ''
+
     """
     tw \\
         $args \\

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -45,10 +45,12 @@ workflow NF_AGGREGATE {
     SEQERA_RUNS_DUMP
         .out
         .run_dump
-        .filter {
-            meta, run_dir ->
-                meta.fusion && !params.skip_run_gantt
-        }
+        // This field is currently not set, see issue: https://github.com/seqeralabs/nf-aggregate/issues/55
+        // .filter {
+        //     meta, run_dir ->
+
+        //         meta.fusion && !params.skip_run_gantt
+        // }
         .set { ch_runs_for_gantt }
 
     PLOT_RUN_GANTT (


### PR DESCRIPTION
For context see: #55 

At the moment the configSlurper cannot handle the way that multiple nested configs are resolved. For viralrecon it currently resolves the publishDir to something like:

```
publishDir = [path:ScriptDF8044060054E44F9089B2B3ABA330E8$_run_closure2$_closure45$_closure49@4c05f83b, mode:'copy', saveAs:ScriptDF8044060054E44F9089B2B3ABA330E8$_run_closure2$_closure45$_closure50@820b78a, enabled:false]
```

This PR removes the automatic retrieval of whether fusion was used until we either find a way to parse this directly or get a completely resolved config for tower.