### PR TITLE
Add process for generating Benchmark reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ nextflow run seqeralabs/nf-aggregate \
 
 If you are using a Seqera Platform Enterprise instance that is secured with a private CA SSL certificate not recognized by default Java certificate authorities, you can specify a custom `cacerts` store path through the `--java_truststore_path` parameter and optionally, a password with the `--java_truststore_password`. This certificate will be used to achieve connectivity with your Seqera Platform instance through API and CLI.
 
+### Benchmark reports
+
+If you want to generate a benchmark report comparing yours runs, you can include a `group` column in your `run_ids.csv` file. This will be used to group the runs in the report.
+
+```
+id,workspace,group
+3VcLMAI8wyy0Ld,community/showcase,group1
+4VLRs7nuqbAhDy,community/showcase,group2
+```
+
+You can also include a `benchmark_aws_cur_report` parameter to include the AWS Cost and Usage Report in the benchmark report. This should be a path to a valid AWS Cost and Usage Report CSV file (locally or in your cloud bucket). To run nf-aggregate with benchmark reports, you can use the following command:
+
+```
+nextflow run seqeralabs/nf-aggregate \
+    --input run_ids.csv \
+    --outdir ./results \
+    --run_benchmark \
+    --benchmark_aws_cur_report ./aws_cost_report.parquet
+```
+
 ## Output
 
 The results from the pipeline will be published in the path specified by the `--outdir` and will consist of the following contents:

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/seqeralabs/nf-aggregate/main/assets/schema_input.json",
     "title": "nf-aggregate pipeline - params.input schema",
     "description": "Schema for the file provided with params.input",
@@ -10,17 +10,20 @@
             "id": {
                 "type": "string",
                 "pattern": "^[A-Za-z0-9]{9,14}$",
-                "errorMessage": "Please provide a valid Seqera Platform run identifier"
+                "errorMessage": "Please provide a valid Seqera Platform run identifier",
+                "meta": ["id"]
             },
             "workspace": {
                 "type": "string",
                 "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){1,38}/[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){1,38}$",
-                "errorMessage": "Please provide a valid Seqera Platform Workspace name"
+                "errorMessage": "Please provide a valid Seqera Platform Workspace name",
+                "meta": ["workspace"]
             },
             "group": {
                 "type": "string",
                 "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){1,38}$",
-                "errorMessage": "Please provide a valid group name"
+                "errorMessage": "Please provide a valid group name",
+                "meta": ["group"]
             }
         },
         "required": ["id", "workspace"]

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -16,6 +16,11 @@
                 "type": "string",
                 "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){1,38}/[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){1,38}$",
                 "errorMessage": "Please provide a valid Seqera Platform Workspace name"
+            },
+            "group": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){1,38}$",
+                "errorMessage": "Please provide a valid group name"
             }
         },
         "required": ["id", "workspace"]

--- a/benchmark_samplesheet.csv
+++ b/benchmark_samplesheet.csv
@@ -1,3 +1,0 @@
-group,file_path
-Fusion,5MmfdfcrptRh6i
-plainS3,20yNeJmbzyHWmq

--- a/benchmark_samplesheet.csv
+++ b/benchmark_samplesheet.csv
@@ -1,0 +1,3 @@
+group,file_path
+Fusion,5MmfdfcrptRh6i
+plainS3,20yNeJmbzyHWmq

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -7,7 +7,6 @@ process BENCHMARK_REPORT {
     path run_dumps
     path benchmark_samplesheet
     path benchmark_report_cost_allocation_file
-    val  benchmark_report_name
 
     output:
     path "benchmark_report.html" , emit: benchmark_html
@@ -27,7 +26,7 @@ process BENCHMARK_REPORT {
     # Set up R environment from renv
     export R_LIBS_USER=/project/renv/library/linux-ubuntu-noble/R-4.4/x86_64-pc-linux-gnu
 
-    quarto render ${benchmark_report_name} \\
+    quarto render main_benchmark_report.qmd \\
         -P log_csv:${benchmark_samplesheet} \\
         --output benchmark_report.html \\
         --output-dir .

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -2,6 +2,7 @@ process BENCHMARK_REPORT {
     debug true
 
     container 'cr.seqera.io/scidev/benchmark-reports:sha-7fe0d8e'
+    stageInMode 'copy'
 
     input:
     path run_dumps

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -26,9 +26,9 @@ process BENCHMARK_REPORT {
     export R_LIBS_USER=/project/renv/library/linux-ubuntu-noble/R-4.4/x86_64-pc-linux-gnu
 
     cd /project
-    echo \$PWD
     quarto render main_benchmark_report.qmd \\
         -P log_csv:"\$initial_workdir/"${benchmark_samplesheet} \\
+        $aws_cost_param \\
         --output-dir .\\
         --output benchmark_report.html
 

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -5,48 +5,36 @@ process BENCHMARK_REPORT {
 
     input:
     path run_dumps
-    val  group
+    path benchmark_samplesheet
     path benchmark_report_cost_allocation_file
     val  benchmark_report_name
 
     output:
+    path "benchmark_report.html" , emit: benchmark_html
     path "versions.yml"          , emit: versions
 
     script:
     def aws_cost_param = benchmark_report_cost_allocation_file ? "--profile cost -P 'aws_cost:/${benchmark_report_cost_allocation_file}'" : ""
-
-    // Create CSV content with all entries - just use filenames for now
-    def csv_content = ["group,file_path"]
-    run_dumps.eachWithIndex { run_dump, i ->
-        csv_content << "${group[i]},${run_dump.toString()}"
-    }
-    def csv_string = csv_content.join('\n')
     """
     export HOME=\$PWD
     export QUARTO_CACHE=/tmp/quarto/cache
     export XDG_CACHE_HOME=/tmp/quarto
     mkdir -p /tmp/quarto/cache
-    chmod -R 777 /tmp/quarto
 
-    echo '${csv_string}' > benchmark_samplesheet.csv
+    cp ${benchmark_samplesheet} /project/${benchmark_samplesheet}
 
     # Set up R environment from renv
     export R_LIBS_USER=/project/renv/library/linux-ubuntu-noble/R-4.4/x86_64-pc-linux-gnu
 
-    # Debug: Check pandoc installation
-    ls -la /opt/quarto/bin/tools || echo "tools dir not found"
-    ls -la /opt/quarto/bin/tools/pandoc || echo "pandoc not found in tools"
-
-    # Add pandoc to PATH
-    export PATH=/opt/quarto/bin/tools/pandoc:\$PATH
-
-    /usr/local/lib/R/bin/Rscript --version
-    pandoc --version || echo "pandoc still not working"
-    quarto check --log-level debug
+    quarto render /project/main_benchmark_report.qmd \\
+        --log-level debug \\
+        -P log_csv:/project/${benchmark_samplesheet} \\
+        --output benchmark_report.html \\
+        --output-dir .
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        R: \$(quarto -v)
+        quarto-cli: \$(quarto -v)
     END_VERSIONS
     """
 }

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -1,0 +1,52 @@
+process BENCHMARK_REPORT {
+    debug true
+
+    container 'cr.seqera.io/scidev/benchmark-reports:sha-7fe0d8e'
+
+    input:
+    path run_dumps
+    val  group
+    path benchmark_report_cost_allocation_file
+    val  benchmark_report_name
+
+    output:
+    path "versions.yml"          , emit: versions
+
+    script:
+    def aws_cost_param = benchmark_report_cost_allocation_file ? "--profile cost -P 'aws_cost:/${benchmark_report_cost_allocation_file}'" : ""
+
+    // Create CSV content with all entries - just use filenames for now
+    def csv_content = ["group,file_path"]
+    run_dumps.eachWithIndex { run_dump, i ->
+        csv_content << "${group[i]},${run_dump.toString()}"
+    }
+    def csv_string = csv_content.join('\n')
+    """
+    export HOME=\$PWD
+    export QUARTO_CACHE=/tmp/quarto/cache
+    export XDG_CACHE_HOME=/tmp/quarto
+    mkdir -p /tmp/quarto/cache
+    chmod -R 777 /tmp/quarto
+
+    echo '${csv_string}' > benchmark_samplesheet.csv
+
+    # Set up R environment from renv
+    export R_LIBS_USER=/project/renv/library/linux-ubuntu-noble/R-4.4/x86_64-pc-linux-gnu
+
+    # Debug: Check pandoc installation
+    ls -la /opt/quarto/bin/tools || echo "tools dir not found"
+    ls -la /opt/quarto/bin/tools/pandoc || echo "pandoc not found in tools"
+
+    # Add pandoc to PATH
+    export PATH=/opt/quarto/bin/tools/pandoc:\$PATH
+
+    /usr/local/lib/R/bin/Rscript --version
+    pandoc --version || echo "pandoc still not working"
+    quarto check --log-level debug
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        R: \$(quarto -v)
+    END_VERSIONS
+    """
+}

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -1,8 +1,6 @@
 process BENCHMARK_REPORT {
-    debug true
 
     container 'cr.seqera.io/scidev/benchmark-reports:sha-7fe0d8e'
-    stageInMode 'copy'
 
     input:
     path run_dumps

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -6,14 +6,14 @@ process BENCHMARK_REPORT {
     input:
     path run_dumps
     path benchmark_samplesheet
-    path benchmark_report_cost_allocation_file
+    path benchmark_aws_cur_report
 
     output:
     path "benchmark_report.html" , emit: benchmark_html
     path "versions.yml"          , emit: versions
 
     script:
-    def aws_cost_param = benchmark_report_cost_allocation_file ? "--profile cost -P aws_cost:/${benchmark_report_cost_allocation_file}" : ""
+    def aws_cost_param = benchmark_aws_cur_report ? "--profile cost -P aws_cost:/${benchmark_aws_cur_report}" : ""
     """
     initial_workdir="\$PWD"
 

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -26,7 +26,7 @@ process BENCHMARK_REPORT {
     # Set up R environment from renv
     export R_LIBS_USER=/project/renv/library/linux-ubuntu-noble/R-4.4/x86_64-pc-linux-gnu
 
-    quarto render /project/main_benchmark_report.qmd \\
+    quarto render /project/${benchmark_report_name} \\
         --log-level debug \\
         -P log_csv:/project/${benchmark_samplesheet} \\
         --output benchmark_report.html \\

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -14,7 +14,7 @@ process BENCHMARK_REPORT {
     path "versions.yml"          , emit: versions
 
     script:
-    def aws_cost_param = benchmark_aws_cur_report ? "--profile cost -P aws_cost:/${benchmark_aws_cur_report}" : ""
+    def aws_cost_param = benchmark_aws_cur_report ? "--profile cost -P aws_cost:\$TASK_DIR/${benchmark_aws_cur_report}" : ""
     def benchmark_samplesheet = "benchmark_samplesheet.csv"
 
     """

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -13,11 +13,10 @@ process BENCHMARK_REPORT {
     path "versions.yml"          , emit: versions
 
     script:
-    def aws_cost_param = benchmark_report_cost_allocation_file ? "--profile cost -P 'aws_cost:/${benchmark_report_cost_allocation_file}'" : ""
+    def aws_cost_param = benchmark_report_cost_allocation_file ? "--profile cost -P aws_cost:/${benchmark_report_cost_allocation_file}" : ""
     """
     initial_workdir="\$PWD"
-    cp ${benchmark_samplesheet} /project/${benchmark_samplesheet}
-    cd /project
+
     export HOME=\$PWD
     export QUARTO_CACHE=/tmp/quarto/cache
     export XDG_CACHE_HOME=/tmp/quarto
@@ -26,10 +25,13 @@ process BENCHMARK_REPORT {
     # Set up R environment from renv
     export R_LIBS_USER=/project/renv/library/linux-ubuntu-noble/R-4.4/x86_64-pc-linux-gnu
 
+    cd /project
+    echo \$PWD
     quarto render main_benchmark_report.qmd \\
-        -P log_csv:${benchmark_samplesheet} \\
-        --output benchmark_report.html \\
-        --output-dir .
+        -P log_csv:"\$initial_workdir/"${benchmark_samplesheet} \\
+        --output-dir .\\
+        --output benchmark_report.html
+
     cp /project/benchmark_report.html "\$initial_workdir/"
     cd "\$initial_workdir/"
 

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -16,21 +16,23 @@ process BENCHMARK_REPORT {
     script:
     def aws_cost_param = benchmark_report_cost_allocation_file ? "--profile cost -P 'aws_cost:/${benchmark_report_cost_allocation_file}'" : ""
     """
+    initial_workdir="\$PWD"
+    cp ${benchmark_samplesheet} /project/${benchmark_samplesheet}
+    cd /project
     export HOME=\$PWD
     export QUARTO_CACHE=/tmp/quarto/cache
     export XDG_CACHE_HOME=/tmp/quarto
     mkdir -p /tmp/quarto/cache
 
-    cp ${benchmark_samplesheet} /project/${benchmark_samplesheet}
-
     # Set up R environment from renv
     export R_LIBS_USER=/project/renv/library/linux-ubuntu-noble/R-4.4/x86_64-pc-linux-gnu
 
-    quarto render /project/${benchmark_report_name} \\
-        --log-level debug \\
-        -P log_csv:/project/${benchmark_samplesheet} \\
+    quarto render ${benchmark_report_name} \\
+        -P log_csv:${benchmark_samplesheet} \\
         --output benchmark_report.html \\
         --output-dir .
+    cp /project/benchmark_report.html "\$initial_workdir/"
+    cd "\$initial_workdir/"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/benchmark_report/nextflow.config
+++ b/modules/local/benchmark_report/nextflow.config
@@ -1,5 +1,9 @@
 process {
     withName: 'BENCHMARK_REPORT' {
-        containerOptions = "-v \$projectDir:/project"
+        publishDir = [
+            path: { "${params.outdir}/${metaOut?.projectName?.replace("/", "_") ?: ""}/benchmark_report" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') || filename.endsWith('.json') ? null : filename }
+        ]
     }
 }

--- a/modules/local/benchmark_report/nextflow.config
+++ b/modules/local/benchmark_report/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: 'BENCHMARK_REPORT' {
+        containerOptions = "-v \$projectDir:/project"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,9 +28,8 @@ params {
     skip_multiqc                 = false
 
     // Benchmark report options
-    benchmark_report_name                 = "main_benchmark_report.qmd"
-    benchmark_report_cost_allocation_file = null
     run_benchmark                         = false
+    benchmark_report_cost_allocation_file = null
 
     // Boilerplate options
     outdir                       = 'results'

--- a/nextflow.config
+++ b/nextflow.config
@@ -177,7 +177,7 @@ singularity.registry = 'quay.io'
 
 // Nextflow plugins
 plugins {
-    id 'nf-validation@1.1.3' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.3.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,9 +29,9 @@ params {
 
     // Benchmark report options
     benchmark_report_name                 = "main_benchmark_report.qmd"
-    benchmark_report_samplesheet          = null
     benchmark_report_cost_allocation_file = null
     run_benchmark                         = false
+
     // Boilerplate options
     outdir                       = 'results'
     publish_dir_mode             = 'copy'

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,6 +27,11 @@ params {
     multiqc_logo                 = null
     skip_multiqc                 = false
 
+    // Benchmark report options
+    benchmark_report_name                 = "main_benchmark_report.qmd"
+    benchmark_report_samplesheet          = null
+    benchmark_report_cost_allocation_file = null
+    run_benchmark                         = false
     // Boilerplate options
     outdir                       = 'results'
     publish_dir_mode             = 'copy'
@@ -52,6 +57,10 @@ process {
     errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
     maxRetries    = 1
     maxErrors     = '-1'
+
+    withName: BENCHMARK_REPORT {
+        containerOptions = '--platform linux/amd64'
+    }
 }
 
 profiles {

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,8 +28,8 @@ params {
     skip_multiqc                 = false
 
     // Benchmark report options
-    run_benchmark                         = false
-    benchmark_aws_cur_report = null
+    run_benchmark                = false
+    benchmark_aws_cur_report     = null
 
     // Boilerplate options
     outdir                       = 'results'

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,9 +58,6 @@ process {
     maxRetries    = 1
     maxErrors     = '-1'
 
-    withName: BENCHMARK_REPORT {
-        containerOptions = '--platform linux/amd64'
-    }
 }
 
 profiles {
@@ -112,7 +109,7 @@ profiles {
         shifter.enabled         = false
         charliecloud.enabled    = false
         apptainer.enabled       = false
-        docker.runOptions       = '-u $(id -u):$(id -g)'
+        // docker.runOptions       = '-u $(id -u):$(id -g)'
     }
     arm {
         docker.runOptions       = '-u $(id -u):$(id -g) --platform=linux/amd64'

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,7 +29,7 @@ params {
 
     // Benchmark report options
     run_benchmark                         = false
-    benchmark_report_cost_allocation_file = null
+    benchmark_aws_cur_report = null
 
     // Boilerplate options
     outdir                       = 'results'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -26,7 +26,8 @@
                     "type": "string",
                     "format": "directory-path",
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
-                    "fa_icon": "fas fa-folder-open"
+                    "fa_icon": "fas fa-folder-open",
+                    "default": "results"
                 }
             }
         },
@@ -73,10 +74,12 @@
                     "fa_icon": "fas fa-tachometer-alt",
                     "description": "Compile a benchmarking report for Seqera Platform runs."
                 },
-                "benchmark_report_cost_allocation_file": {
+                "benchmark_aws_cur_report": {
                     "type": "string",
                     "fa_icon": "fas fa-dollar-sign",
-                    "description": "Cost allocation report from cloud provider. Currently only AWS CUR reports are supported."
+                    "description": "AWS CUR report from data exports.",
+                    "pattern": "^\\S+\\.parquet",
+                    "format": "file-path"
                 }
             },
             "required": ["seqera_api_endpoint"]

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "https://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/seqeralabs/nf-aggregate/main/nextflow_schema.json",
     "title": "seqeralabs/nf-aggregate pipeline parameters",
     "description": "Minimal nf-core pipeline compatible with template",
     "type": "object",
-    "definitions": {
+    "$defs": {
         "input_output_options": {
             "title": "Input/output options",
             "type": "object",
@@ -67,6 +67,16 @@
                     "type": "boolean",
                     "description": "Skip MultiQC.",
                     "fa_icon": "fas fa-fast-forward"
+                },
+                "run_benchmark": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-tachometer-alt",
+                    "description": "Compile a benchmarking report for Seqera Platform runs."
+                },
+                "benchmark_report_cost_allocation_file": {
+                    "type": "string",
+                    "fa_icon": "fas fa-dollar-sign",
+                    "description": "Cost allocation report from cloud provider. Currently only AWS CUR reports are supported."
                 }
             },
             "required": ["seqera_api_endpoint"]
@@ -169,21 +179,13 @@
     },
     "allOf": [
         {
-            "$ref": "#/definitions/input_output_options"
+            "$ref": "#/$defs/input_output_options"
         },
         {
-            "$ref": "#/definitions/pipeline_options"
+            "$ref": "#/$defs/pipeline_options"
         },
         {
-            "$ref": "#/definitions/generic_options"
+            "$ref": "#/$defs/generic_options"
         }
-    ],
-    "properties": {
-        "benchmark_report_cost_allocation_file": {
-            "type": "string"
-        },
-        "run_benchmark": {
-            "type": "boolean"
-        }
-    }
+    ]
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "https://raw.githubusercontent.com/seqeralabs/nf-aggregate/main/nextflow_schema.json",
     "title": "seqeralabs/nf-aggregate pipeline parameters",
     "description": "Minimal nf-core pipeline compatible with template",
@@ -177,5 +177,13 @@
         {
             "$ref": "#/definitions/generic_options"
         }
-    ]
+    ],
+    "properties": {
+        "benchmark_report_cost_allocation_file": {
+            "type": "string"
+        },
+        "run_benchmark": {
+            "type": "boolean"
+        }
+    }
 }

--- a/subworkflows/local/utils_nf_aggregate/main.nf
+++ b/subworkflows/local/utils_nf_aggregate/main.nf
@@ -15,6 +15,7 @@ import java.nio.file.Paths
 include { UTILS_NEXTFLOW_PIPELINE   } from '../../nf-core/utils_nextflow_pipeline/main'
 include { getWorkflowVersion        } from '../../nf-core/utils_nextflow_pipeline/main'
 include { UTILS_NFVALIDATION_PLUGIN } from '../../nf-core/utils_nfvalidation_plugin/main.nf'
+include { samplesheetToList }         from 'plugin/nf-schema'
 
 /*
 ========================================================================================
@@ -53,9 +54,8 @@ workflow PIPELINE_INITIALISATION {
 
     // Read in ids from --input file
     Channel
-        .from(file(params.input))
-        .splitCsv(header:true, sep:',', strip:true)
-        .unique()
+        .fromList(samplesheetToList(params.input, "assets/schema_input.json"))
+        .flatten()
         .set { ch_ids }
 
     emit:

--- a/subworkflows/nf-core/utils_nfvalidation_plugin/main.nf
+++ b/subworkflows/nf-core/utils_nfvalidation_plugin/main.nf
@@ -8,9 +8,9 @@
 ========================================================================================
 */
 
-include { paramsHelp         } from 'plugin/nf-validation'
-include { paramsSummaryLog   } from 'plugin/nf-validation'
-include { validateParameters } from 'plugin/nf-validation'
+include { paramsHelp         } from 'plugin/nf-schema'
+include { paramsSummaryLog   } from 'plugin/nf-schema'
+include { validateParameters } from 'plugin/nf-schema'
 
 /*
 ========================================================================================

--- a/tower.yml
+++ b/tower.yml
@@ -3,3 +3,5 @@ reports:
     display: "MultiQC HTML report"
   "*_gantt.html":
     display: "GANTT plot of task execution in a run, grouped by 'instance-id' if available."
+  benchmark_report.html:
+    display: "Benchmarking HTML report"

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -93,21 +93,6 @@ workflow NF_AGGREGATE {
     if (params.run_benchmark) {
         aws_cur_report = params.benchmark_aws_cur_report ? Channel.fromPath(params.benchmark_aws_cur_report) : []
 
-        // // Create the CSV file using collectFile
-        // SEQERA_RUNS_DUMP.out.run_dump
-        //     .map { meta, run_dir ->
-        //         // Extract filename and prepend '../'
-        //         def filename = "../${file(run_dir).getName()}"
-        //         // Create a line for the CSV
-        //         "${meta.group},${filename}"
-        //     }
-        //     .collectFile(
-        //         name: 'benchmark_samplesheet.csv',
-        //         seed: 'group,file_path',
-        //         newLine: true
-        //     )
-        //     .set { ch_benchmark_csv }
-
         BENCHMARK_REPORT (
             SEQERA_RUNS_DUMP.out.run_dump.collect{it[1]},
             SEQERA_RUNS_DUMP.out.run_dump.collect{it[0].group},

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -88,10 +88,10 @@ workflow NF_AGGREGATE {
     }
 
     //
-    // MODULE: Generate bencharmk report
+    // MODULE: Generate benchmark report
     //
     if (params.run_benchmark) {
-        aws_cur_report = params.benchmark_report_cost_allocation_file ? Channel.fromPath(params.benchmark_report_cost_allocation_file) : []
+        aws_cur_report = params.benchmark_aws_cur_report ? Channel.fromPath(params.benchmark_aws_cur_report) : []
 
         // Create the CSV file using collectFile
         SEQERA_RUNS_DUMP.out.run_dump

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -5,6 +5,7 @@
 include { SEQERA_RUNS_DUMP     } from '../../modules/local/seqera_runs_dump'
 include { PLOT_RUN_GANTT       } from '../../modules/local/plot_run_gantt'
 include { MULTIQC              } from '../../modules/nf-core/multiqc'
+include { BENCHMARK_REPORT     } from '../../modules/local/benchmark_report'
 include { paramsSummaryMultiqc } from '../../subworkflows/local/utils_nf_aggregate'
 include { getProcessVersions   } from '../../subworkflows/local/utils_nf_aggregate'
 include { getWorkflowVersions  } from '../../subworkflows/local/utils_nf_aggregate'
@@ -84,6 +85,20 @@ workflow NF_AGGREGATE {
             multiqc_logo.toList()
         )
         ch_multiqc_report = MULTIQC.out.report
+    }
+
+    //
+    // MODULE: Generate bencharmk report
+    //
+    if (params.run_benchmark) {
+        aws_cur_report = params.benchmark_report_cost_allocation_file ? Channel.fromPath(params.benchmark_report_cost_allocation_file) : []
+
+        BENCHMARK_REPORT (
+            SEQERA_RUNS_DUMP.out.run_dump.collect{it[1]},
+            SEQERA_RUNS_DUMP.out.run_dump.collect{it[0].group},
+            aws_cur_report,
+            params.benchmark_report_name
+        )
     }
 
     emit:

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -9,7 +9,7 @@ include { BENCHMARK_REPORT     } from '../../modules/local/benchmark_report'
 include { paramsSummaryMultiqc } from '../../subworkflows/local/utils_nf_aggregate'
 include { getProcessVersions   } from '../../subworkflows/local/utils_nf_aggregate'
 include { getWorkflowVersions  } from '../../subworkflows/local/utils_nf_aggregate'
-include { paramsSummaryMap     } from 'plugin/nf-validation'
+include { paramsSummaryMap     } from 'plugin/nf-schema'
 
 workflow NF_AGGREGATE {
 
@@ -109,8 +109,7 @@ workflow NF_AGGREGATE {
         BENCHMARK_REPORT (
             SEQERA_RUNS_DUMP.out.run_dump.collect{it[1]},
             ch_benchmark_csv,
-            aws_cur_report,
-            params.benchmark_report_name
+            aws_cur_report
         )
     }
 

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -93,22 +93,24 @@ workflow NF_AGGREGATE {
     if (params.run_benchmark) {
         aws_cur_report = params.benchmark_aws_cur_report ? Channel.fromPath(params.benchmark_aws_cur_report) : []
 
-        // Create the CSV file using collectFile
-        SEQERA_RUNS_DUMP.out.run_dump
-            .map { meta, run_dir ->
-                // Create a line for the CSV
-                "${meta.group},${run_dir}"
-            }
-            .collectFile(
-                name: 'benchmark_samplesheet.csv',
-                seed: 'group,file_path',
-                newLine: true
-            )
-            .set { ch_benchmark_csv }
+        // // Create the CSV file using collectFile
+        // SEQERA_RUNS_DUMP.out.run_dump
+        //     .map { meta, run_dir ->
+        //         // Extract filename and prepend '../'
+        //         def filename = "../${file(run_dir).getName()}"
+        //         // Create a line for the CSV
+        //         "${meta.group},${filename}"
+        //     }
+        //     .collectFile(
+        //         name: 'benchmark_samplesheet.csv',
+        //         seed: 'group,file_path',
+        //         newLine: true
+        //     )
+        //     .set { ch_benchmark_csv }
 
         BENCHMARK_REPORT (
             SEQERA_RUNS_DUMP.out.run_dump.collect{it[1]},
-            ch_benchmark_csv,
+            SEQERA_RUNS_DUMP.out.run_dump.collect{it[0].group},
             aws_cur_report
         )
     }

--- a/workflows/nf_aggregate/nextflow.config
+++ b/workflows/nf_aggregate/nextflow.config
@@ -1,3 +1,4 @@
 includeConfig '../../modules/local/seqera_runs_dump/nextflow.config'
 includeConfig '../../modules/local/plot_run_gantt/nextflow.config'
 includeConfig '../../modules/nf-core/multiqc/nextflow.config'
+includeConfig '../../modules/local/benchmark_report/nextflow.config'


### PR DESCRIPTION
# Description

This PR adds a new process and params to configure compiling a benchmarking report using Quarto. Benchmarking reports enable comparisons between runs for different groups (for example plainS3 vs Fusion). 

Specific features and flags added in this PR:
- New benchmark report module
- Possibility to specify AWS cost report to include costing in report

Still currently missing:
- Excluding failed tasks from report