### PR TITLE
change: Making samplesheet group validation accept loser formatting.

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -21,7 +21,7 @@
             },
             "group": {
                 "type": "string",
-                "pattern": "^[a-zA-Z0-9](?:[a-zA-Z0-9]|[-_](?=[a-zA-Z0-9])){1,38}$",
+                "pattern": "^[a-zA-Z0-9][-a-zA-Z0-9_ ]{0,37}$",
                 "errorMessage": "Please provide a valid group name",
                 "meta": ["group"]
             }

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -9,4 +9,4 @@ multiqc/multiqc_plots/{svg,pdf,png}/*.{svg,pdf,png}
 multiqc/multiqc_report.html
 nf-core_*/gantt/*_gantt.html
 pipeline_info/*.{html,json,txt,yml}
-runs_dump/**/service-info.json
+**/runs_dump/**/service-info.json

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -4,7 +4,7 @@ multiqc/multiqc_data/multiqc_data.json
 multiqc/multiqc_data/multiqc_general_stats.txt
 multiqc/multiqc_data/multiqc_sources.txt
 multiqc/multiqc_data/multiqc_software_version.txt
-s.txt:md5,ffd82573d0a86a65849475c90973c s.txt
+multiqc/multiqc_data/multiqc_seqera_cli.txt
 multiqc/multiqc_plots/{svg,pdf,png}/*.{svg,pdf,png}
 multiqc/multiqc_report.html
 nf-core_*/gantt/*_gantt.html

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -3,7 +3,10 @@ multiqc/multiqc_data/multiqc.log
 multiqc/multiqc_data/multiqc_data.json
 multiqc/multiqc_data/multiqc_general_stats.txt
 multiqc/multiqc_data/multiqc_sources.txt
+multiqc/multiqc_data/multiqc_software_version
+s.txt:md5,ffd82573d0a86a65849475c90973c s.txt
 multiqc/multiqc_plots/{svg,pdf,png}/*.{svg,pdf,png}
 multiqc/multiqc_report.html
 nf-core_*/gantt/*_gantt.html
 pipeline_info/*.{html,json,txt,yml}
+runs_dump/**/service-info.json

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -3,7 +3,7 @@ multiqc/multiqc_data/multiqc.log
 multiqc/multiqc_data/multiqc_data.json
 multiqc/multiqc_data/multiqc_general_stats.txt
 multiqc/multiqc_data/multiqc_sources.txt
-multiqc/multiqc_data/multiqc_software_version
+multiqc/multiqc_data/multiqc_software_version.txt
 s.txt:md5,ffd82573d0a86a65849475c90973c s.txt
 multiqc/multiqc_plots/{svg,pdf,png}/*.{svg,pdf,png}
 multiqc/multiqc_report.html

--- a/tests/.nftignore
+++ b/tests/.nftignore
@@ -3,7 +3,7 @@ multiqc/multiqc_data/multiqc.log
 multiqc/multiqc_data/multiqc_data.json
 multiqc/multiqc_data/multiqc_general_stats.txt
 multiqc/multiqc_data/multiqc_sources.txt
-multiqc/multiqc_data/multiqc_software_version.txt
+multiqc/multiqc_data/multiqc_software_versions.txt
 multiqc/multiqc_data/multiqc_seqera_cli.txt
 multiqc/multiqc_plots/{svg,pdf,png}/*.{svg,pdf,png}
 multiqc/multiqc_report.html

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -115,35 +115,30 @@
                 "seqera_cli_cpu_time_plot.txt:md5,390f4051d6092a84a2b3f73ab10643c5",
                 "seqera_cli_process_statuses_plot.txt:md5,13414743798b07baebe846fb8d20bdde",
                 "seqera_cli_wall_time_plot.txt:md5,abc859f5fe0dabfcded8c658de70725a",
-                "service-info.json:md5,7ddb184f79cbe6cadd76e712d07109f9",
                 "workflow-launch.json:md5,a842489f283947ea92a4f88826bbabf0",
                 "workflow-load.json:md5,947517e30d5485ad97601923f2ccb2f5",
                 "workflow-metadata.json:md5,99ec56750319402d9eed979b51527d0e",
                 "workflow-metrics.json:md5,a862f20aabadbc5ab0be91642dffc00c",
                 "workflow-tasks.json:md5,7301efc1db5ee06cd57be6b6ea901f36",
                 "workflow.json:md5,59f3848c26e6b99155240a61e57222bf",
-                "service-info.json:md5,7ddb184f79cbe6cadd76e712d07109f9",
                 "workflow-launch.json:md5,6fdbe8c3a57a9e0e11d65d0057a074e4",
                 "workflow-load.json:md5,7fe53d3eb1bd3e8ab882d011a751b832",
                 "workflow-metadata.json:md5,01f59714a52a57456219a95cdb29cb5a",
                 "workflow-metrics.json:md5,15b8927b842c6fd1fc738af2e8d3462e",
                 "workflow-tasks.json:md5,26adadf43dd7f5d9996b3ff6c5698ff6",
                 "workflow.json:md5,0f7da8cd7d2bfe2b72bc0dc4cbb0fbc0",
-                "service-info.json:md5,7ddb184f79cbe6cadd76e712d07109f9",
                 "workflow-launch.json:md5,032225ac0735972950537a3b5e913662",
                 "workflow-load.json:md5,4f02d5a24ab89aa648cd4346785c8f2c",
                 "workflow-metadata.json:md5,4347508e26b93645bd393157856f0860",
                 "workflow-metrics.json:md5,13a5b5d7447fad4a8baa053d1abf85e5",
                 "workflow-tasks.json:md5,577a7472816b7729012a9291d97ff150",
                 "workflow.json:md5,658701f8d7af1b7112534a7f58cd9aa7",
-                "service-info.json:md5,7ddb184f79cbe6cadd76e712d07109f9",
                 "workflow-launch.json:md5,1ccf29020c410b00fdc02537ce7a813e",
                 "workflow-load.json:md5,2f5abdb8efc1fdb249378cb1af093a4a",
                 "workflow-metadata.json:md5,2fc6fdbe5bfc7cc90b92725c586c3cd3",
                 "workflow-metrics.json:md5,5cb0d8e859991831eff666eed1c97b3e",
                 "workflow-tasks.json:md5,bf390ebbe51b2dc7aea4c60a4a02ee97",
                 "workflow.json:md5,a81b1319f6a6038d1b2de9f8c7ddb8b6",
-                "service-info.json:md5,7ddb184f79cbe6cadd76e712d07109f9",
                 "workflow-launch.json:md5,56995097a449167c11769a566c7d2716",
                 "workflow-load.json:md5,bebdd4917d3b769a656744ba25241898",
                 "workflow-metadata.json:md5,3dcba41db4802a3a43e6660e7cd9b759",
@@ -154,8 +149,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.01.0"
         },
-        "timestamp": "2025-03-05T19:38:16.222696097"
+        "timestamp": "2025-03-06T15:24:45.778706803"
     }
 }

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -3,14 +3,14 @@
         "content": [
             10,
             {
+                "Workflow": {
+                    "seqeralabs/nf-aggregate": "0.6.0"
+                },
                 "PLOT_RUN_GANTT": {
                     "python": "3.9.19",
                     "pandas": "1.1.5",
                     "plotly_express": "0.4.1",
                     "click": "8.0.1"
-                },
-                "Workflow": {
-                    "seqeralabs/nf-aggregate": "0.6.0"
                 },
                 "SEQERA_RUNS_DUMP": {
                     "seqera-cli": "0.9.2 (build 39a2ec6)"

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -111,8 +111,6 @@
             ],
             [
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
-                "multiqc_seqera_cli.txt:md5,686de4c7ada09286b6d5b42291064045",
-                "multiqc_software_versions.txt:md5,c04eeacc50b80424ef1b89cd966229a9",
                 "seqera_cli_cost_plot.txt:md5,5f6c0eec1ee86691a6d2914e163a5767",
                 "seqera_cli_cpu_time_plot.txt:md5,390f4051d6092a84a2b3f73ab10643c5",
                 "seqera_cli_process_statuses_plot.txt:md5,13414743798b07baebe846fb8d20bdde",
@@ -158,6 +156,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.5"
         },
-        "timestamp": "2025-03-05T16:22:49.945677813"
+        "timestamp": "2025-03-05T19:38:16.222696097"
     }
 }

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -3,14 +3,14 @@
         "content": [
             10,
             {
-                "Workflow": {
-                    "seqeralabs/nf-aggregate": "0.6.0"
-                },
                 "PLOT_RUN_GANTT": {
                     "python": "3.9.19",
                     "pandas": "1.1.5",
                     "plotly_express": "0.4.1",
                     "click": "8.0.1"
+                },
+                "Workflow": {
+                    "seqeralabs/nf-aggregate": "0.6.0"
                 },
                 "SEQERA_RUNS_DUMP": {
                     "seqera-cli": "0.9.2 (build 39a2ec6)"
@@ -111,41 +111,41 @@
             ],
             [
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
-                "multiqc_seqera_cli.txt:md5,f7dc6872f13a1c9fe989b84540a940ff",
-                "multiqc_software_versions.txt:md5,ffd82573d0a86a65849475c90973c980",
+                "multiqc_seqera_cli.txt:md5,686de4c7ada09286b6d5b42291064045",
+                "multiqc_software_versions.txt:md5,c04eeacc50b80424ef1b89cd966229a9",
                 "seqera_cli_cost_plot.txt:md5,5f6c0eec1ee86691a6d2914e163a5767",
                 "seqera_cli_cpu_time_plot.txt:md5,390f4051d6092a84a2b3f73ab10643c5",
                 "seqera_cli_process_statuses_plot.txt:md5,13414743798b07baebe846fb8d20bdde",
                 "seqera_cli_wall_time_plot.txt:md5,abc859f5fe0dabfcded8c658de70725a",
-                "service-info.json:md5,5738071394871f50948ae77090d4af50",
+                "service-info.json:md5,7ddb184f79cbe6cadd76e712d07109f9",
                 "workflow-launch.json:md5,a842489f283947ea92a4f88826bbabf0",
                 "workflow-load.json:md5,947517e30d5485ad97601923f2ccb2f5",
                 "workflow-metadata.json:md5,99ec56750319402d9eed979b51527d0e",
                 "workflow-metrics.json:md5,a862f20aabadbc5ab0be91642dffc00c",
                 "workflow-tasks.json:md5,7301efc1db5ee06cd57be6b6ea901f36",
                 "workflow.json:md5,59f3848c26e6b99155240a61e57222bf",
-                "service-info.json:md5,5738071394871f50948ae77090d4af50",
+                "service-info.json:md5,7ddb184f79cbe6cadd76e712d07109f9",
                 "workflow-launch.json:md5,6fdbe8c3a57a9e0e11d65d0057a074e4",
                 "workflow-load.json:md5,7fe53d3eb1bd3e8ab882d011a751b832",
                 "workflow-metadata.json:md5,01f59714a52a57456219a95cdb29cb5a",
                 "workflow-metrics.json:md5,15b8927b842c6fd1fc738af2e8d3462e",
                 "workflow-tasks.json:md5,26adadf43dd7f5d9996b3ff6c5698ff6",
                 "workflow.json:md5,0f7da8cd7d2bfe2b72bc0dc4cbb0fbc0",
-                "service-info.json:md5,5738071394871f50948ae77090d4af50",
+                "service-info.json:md5,7ddb184f79cbe6cadd76e712d07109f9",
                 "workflow-launch.json:md5,032225ac0735972950537a3b5e913662",
                 "workflow-load.json:md5,4f02d5a24ab89aa648cd4346785c8f2c",
                 "workflow-metadata.json:md5,4347508e26b93645bd393157856f0860",
                 "workflow-metrics.json:md5,13a5b5d7447fad4a8baa053d1abf85e5",
                 "workflow-tasks.json:md5,577a7472816b7729012a9291d97ff150",
                 "workflow.json:md5,658701f8d7af1b7112534a7f58cd9aa7",
-                "service-info.json:md5,5738071394871f50948ae77090d4af50",
+                "service-info.json:md5,7ddb184f79cbe6cadd76e712d07109f9",
                 "workflow-launch.json:md5,1ccf29020c410b00fdc02537ce7a813e",
                 "workflow-load.json:md5,2f5abdb8efc1fdb249378cb1af093a4a",
                 "workflow-metadata.json:md5,2fc6fdbe5bfc7cc90b92725c586c3cd3",
                 "workflow-metrics.json:md5,5cb0d8e859991831eff666eed1c97b3e",
                 "workflow-tasks.json:md5,bf390ebbe51b2dc7aea4c60a4a02ee97",
                 "workflow.json:md5,a81b1319f6a6038d1b2de9f8c7ddb8b6",
-                "service-info.json:md5,5738071394871f50948ae77090d4af50",
+                "service-info.json:md5,7ddb184f79cbe6cadd76e712d07109f9",
                 "workflow-launch.json:md5,56995097a449167c11769a566c7d2716",
                 "workflow-load.json:md5,bebdd4917d3b769a656744ba25241898",
                 "workflow-metadata.json:md5,3dcba41db4802a3a43e6660e7cd9b759",
@@ -156,8 +156,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.01.0"
+            "nextflow": "24.10.5"
         },
-        "timestamp": "2025-02-27T13:21:17.488661076"
+        "timestamp": "2025-03-05T16:22:49.945677813"
     }
 }


### PR DESCRIPTION
<!--
# seqeralabs/nf-aggregate pull request

Many thanks for contributing to seqeralabs/nf-aggregate!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/seqeralabs/nf-aggregate/tree/master/.github/CONTRIBUTING.md)
-->
# Description

This PR changes the validation for the samplesheet column `group` to allow group definitions like `Fusion v2`, `plain S3` or other definitions with commas or hyphens.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/seqeralabs/nf-aggregate/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
