### PR TITLE
Bump benchmark image version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,14 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 
 - [PR #88](https://github.com/seqeralabs/nf-aggregate/pull/88) - Update tw cli container version to 0.11.2 and allow .nextflow.log to be missing from tw call
 - [PR #89](https://github.com/seqeralabs/nf-aggregate/pull/89) - Enable usage of external run dumps with nf-aggregate & update devcontainer specifications
+- [PR #]() - Update benchmark report image to include a fix causing large memory footprint for reshaping large AWS cost report files
 
 ### Software dependencies
 
-| Dependency  | Old version | New version |
-| ----------- | ----------- | ----------- |
-| `tower-cli` | 0.9.2       | 0.11.2      |
+| Dependency        | Old version | New version |
+| ----------------- | ----------- | ----------- |
+| `tower-cli`       | 0.9.2       | 0.11.2      |
+| BENCHMARK_REPORTS | sha-48cfed7 | sha-a6d15e8 |
 
 > **NB:** Dependency has been **updated** if both old and new version information is present.
 >

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 
 - [PR #88](https://github.com/seqeralabs/nf-aggregate/pull/88) - Update tw cli container version to 0.11.2 and allow .nextflow.log to be missing from tw call
 - [PR #89](https://github.com/seqeralabs/nf-aggregate/pull/89) - Enable usage of external run dumps with nf-aggregate & update devcontainer specifications
-- [PR #]() - Update benchmark report image to include a fix causing large memory footprint for reshaping large AWS cost report files
+- [PR #91](https://github.com/seqeralabs/nf-aggregate/pull/91) - Update benchmark report image to include a fix causing large memory footprint for reshaping large AWS cost report files
 
 ### Software dependencies
 

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -1,6 +1,6 @@
 process BENCHMARK_REPORT {
 
-    container 'cr.seqera.io/scidev/benchmark-reports:sha-48cfed7'
+    container 'cr.seqera.io/scidev/benchmark-reports:sha-a6d15e8'
 
     input:
     path run_dumps


### PR DESCRIPTION
# Description

This PR updates the benchmark report container version to include a fix for parsin CUR2.0 reports more efficiently with a lower memory footprint.