### PR TITLE
Update nextflow.config to enable skip_run_gantt option and adjust workflow logic accordingly

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -13,7 +13,7 @@ params {
     input                        = null
 
     // General pipeline options
-    skip_run_gantt               = false
+    skip_run_gantt               = true
 
     // Seqera CLI options
     seqera_api_endpoint          = "https://api.cloud.seqera.io"

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -6,7 +6,7 @@ nextflow_pipeline {
     tag "nf-aggregate"
 
     test("-profile test") {
-
+        tag( "test")
         when {
             params {
                 outdir = "$outputDir"
@@ -34,7 +34,8 @@ nextflow_pipeline {
         }
     }
 
-        test("-profile test_benchmark") {
+    test("-profile test_benchmark") {
+        tag("benchmark")
 
         when {
             params {

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -1,14 +1,8 @@
 {
     "-profile test": {
         "content": [
-            10,
+            6,
             {
-                "PLOT_RUN_GANTT": {
-                    "python": "3.9.19",
-                    "pandas": "1.1.5",
-                    "plotly_express": "0.4.1",
-                    "click": "8.0.1"
-                },
                 "SEQERA_RUNS_DUMP": {
                     "seqera-cli": "0.11.2 (build 2a4e8d5)"
                 },
@@ -54,8 +48,6 @@
                 "multiqc/multiqc_plots/svg/seqera_cli_wall_time_plot.svg",
                 "multiqc/multiqc_report.html",
                 "nf-core_ampliseq",
-                "nf-core_ampliseq/gantt",
-                "nf-core_ampliseq/gantt/2lXd1j7OwZVfxh_gantt.html",
                 "nf-core_ampliseq/runs_dump",
                 "nf-core_ampliseq/runs_dump/2lXd1j7OwZVfxh",
                 "nf-core_ampliseq/runs_dump/2lXd1j7OwZVfxh/service-info.json",
@@ -66,9 +58,6 @@
                 "nf-core_ampliseq/runs_dump/2lXd1j7OwZVfxh/workflow-tasks.json",
                 "nf-core_ampliseq/runs_dump/2lXd1j7OwZVfxh/workflow.json",
                 "nf-core_rnaseq",
-                "nf-core_rnaseq/gantt",
-                "nf-core_rnaseq/gantt/4Bi5xBK6E2Nbhj_gantt.html",
-                "nf-core_rnaseq/gantt/4LWT4uaXDaGcDY_gantt.html",
                 "nf-core_rnaseq/runs_dump",
                 "nf-core_rnaseq/runs_dump/3iFMo0NtH1Byvy",
                 "nf-core_rnaseq/runs_dump/3iFMo0NtH1Byvy/service-info.json",
@@ -95,8 +84,6 @@
                 "nf-core_rnaseq/runs_dump/4LWT4uaXDaGcDY/workflow-tasks.json",
                 "nf-core_rnaseq/runs_dump/4LWT4uaXDaGcDY/workflow.json",
                 "nf-core_scrnaseq",
-                "nf-core_scrnaseq/gantt",
-                "nf-core_scrnaseq/gantt/38QXz4OfQDpwOV_gantt.html",
                 "nf-core_scrnaseq/runs_dump",
                 "nf-core_scrnaseq/runs_dump/38QXz4OfQDpwOV",
                 "nf-core_scrnaseq/runs_dump/38QXz4OfQDpwOV/service-info.json",
@@ -149,9 +136,9 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nextflow": "25.04.3"
         },
-        "timestamp": "2025-05-02T03:31:32.312298"
+        "timestamp": "2025-06-03T20:39:31.908143839"
     },
     "-profile test_benchmark": {
         "content": [

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -3,11 +3,11 @@
         "content": [
             6,
             {
-                "SEQERA_RUNS_DUMP": {
-                    "seqera-cli": "0.11.2 (build 2a4e8d5)"
-                },
                 "Workflow": {
                     "seqeralabs/nf-aggregate": "0.7.0"
+                },
+                "SEQERA_RUNS_DUMP": {
+                    "seqera-cli": "0.11.2 (build 2a4e8d5)"
                 }
             },
             [
@@ -144,12 +144,12 @@
         "content": [
             1,
             {
+                "Workflow": {
+                    "seqeralabs/nf-aggregate": "0.7.0"
+                },
                 "BENCHMARK_REPORT": {
                     "r": "4.4.2",
                     "quarto-cli": "1.5.55"
-                },
-                "Workflow": {
-                    "seqeralabs/nf-aggregate": "0.7.0"
                 }
             },
             [
@@ -159,7 +159,7 @@
                 "pipeline_info/collated_software_mqc_versions.yml"
             ],
             [
-                
+
             ]
         ],
         "meta": {

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -60,7 +60,7 @@ workflow NF_AGGREGATE {
     //
     // MODULE: Generate Gantt chart for workflow execution
     //
-    if(!params.skip_run_gantt){
+    if(!skip_run_gantt){
         ch_all_runs
             .filter { meta, _run_dir -> meta.fusion}
             .set { ch_runs_for_gantt }


### PR DESCRIPTION
# Description

Turn off GANTT report generation by default, which also disables pulling of individual task logs, which should make SEQERA_RUNS_DUMP faster. Users can still turn this feature on, but we have not been using it in most cases and it therefore seems sensible to turn it off.

Closes #93 