### PR TITLE
Fix: Updated devcontainer setup

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,17 +1,8 @@
 #!/usr/bin/env bash
 
-# Fix for Java options
-printf 'unset JAVA_TOOL_OPTIONS\n' >> $HOME/.bashrc
-unset JAVA_TOOL_OPTIONS
-
 # Customise the terminal command prompt
 printf "export PS1='\\[\\e[3;36m\\]\${PWD#/workspaces/} ->\\[\\e[0m\\] '\n" >> $HOME/.bashrc
 export PS1='\[\e[3;36m\]${PWD#/workspaces/} ->\[\e[0m\] '
-
-# Force Java environment variables to use conda installation
-printf 'export JAVA_HOME=/opt/conda\nexport JAVA_CMD=/opt/conda/bin/java\n' >> $HOME/.bashrc
-export JAVA_HOME=/opt/conda
-export JAVA_CMD=/opt/conda/bin/java
 
 # Update Nextflow
 nextflow self-update


### PR DESCRIPTION
# Description

The current devcontainer setup is broken and doesn't have JAVA enabled properly. Updating the setup to mirror current Nextflow training setup.