### PR TITLE
Add AGENTS.md with Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,14 @@ This is a **Nextflow DSL2 bioinformatics pipeline** (not a web app). It aggregat
 
 ### Required tools
 
-| Tool | Version | Purpose |
-|------|---------|---------|
-| Nextflow | >= 24.04.2 (use `NXF_VER=24.10.4`) | Workflow engine |
-| Java JDK | 11+ | Nextflow runtime |
-| Docker | latest | Container runtime for pipeline processes |
-| nf-test | >= 0.9.2 | Test framework |
-| nf-core | 3.3.1 | Pipeline linting |
-| pre-commit | latest | Code formatting hooks (prettier, trailing-whitespace, end-of-file-fixer) |
+| Tool       | Version                            | Purpose                                                                  |
+| ---------- | ---------------------------------- | ------------------------------------------------------------------------ |
+| Nextflow   | >= 24.04.2 (use `NXF_VER=24.10.4`) | Workflow engine                                                          |
+| Java JDK   | 11+                                | Nextflow runtime                                                         |
+| Docker     | latest                             | Container runtime for pipeline processes                                 |
+| nf-test    | >= 0.9.2                           | Test framework                                                           |
+| nf-core    | 3.3.1                              | Pipeline linting                                                         |
+| pre-commit | latest                             | Code formatting hooks (prettier, trailing-whitespace, end-of-file-fixer) |
 
 ### Running the pipeline
 
@@ -50,6 +50,7 @@ nf-test test --tag subworkflows --verbose
 ### Docker-in-Docker setup (Cloud VM)
 
 The Cloud VM requires special Docker configuration:
+
 - `fuse-overlayfs` storage driver (kernel doesn't support all overlay2 features)
 - `iptables-legacy` (kernel doesn't support all nftables features)
 - Docker daemon must be started manually: `sudo dockerd &>/tmp/dockerd.log &`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+This is a **Nextflow DSL2 bioinformatics pipeline** (not a web app). It aggregates metrics across pipeline runs on the Seqera Platform. There are no databases, no package managers (npm/pip), and no traditional build steps.
+
+### Required tools
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Nextflow | >= 24.04.2 (use `NXF_VER=24.10.4`) | Workflow engine |
+| Java JDK | 11+ | Nextflow runtime |
+| Docker | latest | Container runtime for pipeline processes |
+| nf-test | >= 0.9.2 | Test framework |
+| nf-core | 3.3.1 | Pipeline linting |
+| pre-commit | latest | Code formatting hooks (prettier, trailing-whitespace, end-of-file-fixer) |
+
+### Running the pipeline
+
+The pipeline requires `TOWER_ACCESS_TOKEN` (Seqera Platform API token) exported as an environment variable. Without it, the pipeline will fail at the `SEQERA_RUNS_DUMP` process. Add it as a secret named `TOWER_ACCESS_TOKEN`.
+
+```bash
+export TOWER_ACCESS_TOKEN=<your-token>
+nextflow run . -profile test,docker --outdir ./results
+```
+
+### Linting
+
+```bash
+pre-commit run --all-files
+nf-core pipelines lint --dir .
+```
+
+### Testing
+
+See `.github/CONTRIBUTING.md` for the canonical test command:
+
+```bash
+nf-test test --profile debug,test,docker --verbose
+```
+
+All pipeline and module tests require `TOWER_ACCESS_TOKEN` because they call the Seqera Platform API. The only tests that can run without a token are the utility subworkflow tests:
+
+```bash
+nf-test test --tag subworkflows --verbose
+```
+
+### Docker-in-Docker setup (Cloud VM)
+
+The Cloud VM requires special Docker configuration:
+- `fuse-overlayfs` storage driver (kernel doesn't support all overlay2 features)
+- `iptables-legacy` (kernel doesn't support all nftables features)
+- Docker daemon must be started manually: `sudo dockerd &>/tmp/dockerd.log &`
+
+### Key files
+
+- `main.nf` — pipeline entry point
+- `nextflow.config` — main config (params, profiles, plugins)
+- `nf-test.config` — test framework config
+- `.pre-commit-config.yaml` — linting hooks
+- `.nf-core.yml` — lint ignore rules
+- `workflows/nf_aggregate/main.nf` — primary workflow logic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ The pipeline requires `TOWER_ACCESS_TOKEN` (Seqera Platform API token) exported 
 
 ```bash
 export TOWER_ACCESS_TOKEN=<your-token>
-nextflow run . -profile test,docker --outdir ./results
+NXF_DOCKER_LEGACY=true nextflow run . -profile test,docker --outdir ./results -c /tmp/nf-no-limits.config
 ```
 
 ### Linting
@@ -35,10 +35,10 @@ nf-core pipelines lint --dir .
 
 ### Testing
 
-See `.github/CONTRIBUTING.md` for the canonical test command:
+See `.github/CONTRIBUTING.md` for the canonical test command. In the Cloud VM, you must use the custom nf-test config to disable Docker resource limits:
 
 ```bash
-nf-test test --profile debug,test,docker --verbose
+NXF_DOCKER_LEGACY=true nf-test test tests/default.nf.test --profile debug,test,docker --verbose --config /tmp/nf-test-cloud.config
 ```
 
 All pipeline and module tests require `TOWER_ACCESS_TOKEN` because they call the Seqera Platform API. The only tests that can run without a token are the utility subworkflow tests:
@@ -54,6 +54,30 @@ The Cloud VM requires special Docker configuration:
 - `fuse-overlayfs` storage driver (kernel doesn't support all overlay2 features)
 - `iptables-legacy` (kernel doesn't support all nftables features)
 - Docker daemon must be started manually: `sudo dockerd &>/tmp/dockerd.log &`
+- After starting Docker: `sudo chmod 666 /var/run/docker.sock`
+
+### Cgroup v2 workaround (critical for Cloud VM)
+
+The Cloud VM's cgroup v2 is in "threaded" mode, which prevents Docker from applying resource limits (`--memory`, `--cpu-shares`). Nextflow by default passes these flags to `docker run`, causing all containerized processes to fail with `cannot enter cgroupv2 ... with domain controllers -- it is in threaded mode`.
+
+**Workaround:** You must disable Docker resource limits in two ways:
+
+1. Set `NXF_DOCKER_LEGACY=true` (avoids `--cpu-shares`)
+2. Pass a Nextflow config that nullifies process resource settings:
+
+```bash
+cat > /tmp/nf-no-limits.config << 'EOF'
+process {
+    memory = null
+    cpus = null
+    time = null
+}
+EOF
+```
+
+For nf-test, create `/tmp/nf-test-cloud.config` that references a combined Nextflow test config (including resource nullification) and use `--config /tmp/nf-test-cloud.config`.
+
+The snapshot test for the default profile (`-profile test`) has a **pre-existing mismatch** caused by upstream data drift (Seqera Platform runs now include additional files like fusion logs and task directories not in the original snapshot). The benchmark test passes.
 
 ### Key files
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Add `AGENTS.md` with Cursor Cloud-specific development environment instructions for future cloud agents. This documents the required tools, linting commands, testing procedures, Docker-in-Docker setup caveats, and the **critical cgroup v2 workaround** for the cloud VM environment.

### Key learnings documented

- Cloud VM's cgroup v2 is in "threaded" mode, which prevents Docker resource limits (`--memory`, `--cpu-shares`). Nextflow passes these by default, breaking all containerized processes.
- Workaround: `NXF_DOCKER_LEGACY=true` + a Nextflow config that nullifies `process { memory = null; cpus = null; time = null }`.
- Docker socket requires `chmod 666` after daemon start for non-root Nextflow execution.

### Validation

- Pipeline ran end-to-end with `-profile test,docker`: 3 `SEQERA_RUNS_DUMP` + 1 `MULTIQC` all completed successfully
- nf-test benchmark test: PASSED
- nf-test default test: snapshot mismatch (pre-existing upstream data drift, not related to changes)
- `pre-commit run --all-files`: PASSED
- `nf-core pipelines lint`: 142 passed, 0 failed

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/seqeralabs/nf-aggregate/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`). — Pipeline runs successfully end-to-end
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b880e3c-d245-4df5-a90c-cfd1e43fe91b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b880e3c-d245-4df5-a90c-cfd1e43fe91b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

