### PR TITLE
Repair benchmark report workflow compatibility

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,26 +8,17 @@ These are the most common things requested on pull requests (PRs).
 
 Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.
 
-<<<<<<< HEAD
-Learn more about contributing: [CONTRIBUTING.md](https://github.com/seqeralabs/nf-aggregate/tree/master/.github/CONTRIBUTING.md)
-=======
 Learn more about contributing: [CONTRIBUTING.md](https://github.com/seqeralabs/nf-aggregate/tree/main/.github/CONTRIBUTING.md)
->>>>>>> aca0dae (initial template build from nf-core/tools, version 3.2.0)
 -->
 
 ## PR checklist
 
 - [ ] This comment contains a description of changes (with reason).
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
-<<<<<<< HEAD
-- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/seqeralabs/nf-aggregate/tree/master/.github/CONTRIBUTING.md)
+- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/seqeralabs/nf-aggregate/tree/main/.github/CONTRIBUTING.md)
 - [ ] Make sure your code lints (`nf-core pipelines lint`).
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
 - [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
-=======
-- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/seqeralabs/nf-aggregate/tree/main/.github/CONTRIBUTING.md)
-- [ ] Make sure your code lints (`nf-core pipelines lint`).
->>>>>>> aca0dae (initial template build from nf-core/tools, version 3.2.0)
 - [ ] Usage Documentation in `docs/usage.md` is updated.
 - [ ] Output Documentation in `docs/output.md` is updated.
 - [ ] `CHANGELOG.md` is updated.

--- a/bin/benchmark_report.py
+++ b/bin/benchmark_report.py
@@ -2,7 +2,6 @@
 """Generate benchmark report matching the Quarto/R reference, using Python + DuckDB + eCharts."""
 
 import json
-import sys
 from pathlib import Path
 from datetime import datetime
 
@@ -31,12 +30,71 @@ def load_run_data(data_dir: Path) -> list[dict]:
     return runs
 
 
+def load_run_dumps(dump_dir: Path) -> list[dict]:
+    """Load unpacked `tw runs dump` directories into the report data model."""
+    runs = []
+    for run_dir in sorted(path for path in dump_dir.iterdir() if path.is_dir()):
+        workflow_path = run_dir / "workflow.json"
+        tasks_path = run_dir / "workflow-tasks.json"
+        metrics_path = run_dir / "workflow-metrics.json"
+        progress_path = run_dir / "workflow-load.json"
+        launch_path = run_dir / "workflow-launch.json"
+        service_info_path = run_dir / "service-info.json"
+
+        if not workflow_path.exists():
+            continue
+
+        with workflow_path.open() as f:
+            workflow = json.load(f)
+        with tasks_path.open() as f:
+            tasks = json.load(f) if tasks_path.exists() else []
+        with metrics_path.open() as f:
+            metrics = json.load(f) if metrics_path.exists() else []
+        with progress_path.open() as f:
+            progress = json.load(f) if progress_path.exists() else {}
+        with launch_path.open() as f:
+            launch = json.load(f) if launch_path.exists() else {}
+        with service_info_path.open() as f:
+            service_info = json.load(f) if service_info_path.exists() else {}
+
+        group = workflow.get("label") or workflow.get("group") or "default"
+        if isinstance(workflow.get("labels"), list) and workflow["labels"]:
+            group = workflow["labels"][0]
+
+        runs.append(
+            {
+                "meta": {
+                    "id": workflow.get("id", run_dir.name),
+                    "group": group,
+                    "workspace": workflow.get("workspaceName") or workflow.get("workspace", ""),
+                },
+                "workflow": workflow,
+                "metrics": metrics,
+                "tasks": tasks,
+                "progress": progress,
+                "launch": launch,
+                "computeEnv": service_info.get("computeEnv") or service_info.get("computeEnvironment") or {},
+            }
+        )
+    return runs
+
+
 def _write_tmp_json(rows: list[dict], name: str) -> str:
     import tempfile, os
     path = os.path.join(tempfile.gettempdir(), f"nfagg_{name}.json")
     with open(path, "w") as f:
         json.dump(rows, f)
     return path
+
+
+def _first_present(mapping: dict | None, *keys: str):
+    if not isinstance(mapping, dict):
+        return None
+    for key in keys:
+        value = mapping.get(key)
+        if value is not None:
+            return value
+    return None
 
 
 def build_database(runs: list[dict], cur_path: str | None = None) -> duckdb.DuckDBPyConnection:
@@ -47,7 +105,8 @@ def build_database(runs: list[dict], cur_path: str | None = None) -> duckdb.Duck
     run_rows = []
     for r in runs:
         wf = r["workflow"]
-        prog = r.get("progress", {}).get("workflowProgress", {})
+        progress_payload = r.get("progress", {}) or {}
+        prog = progress_payload.get("workflowProgress", progress_payload)
         stats = wf.get("stats", {})
         config = wf.get("configProfiles", "")
         launch = r.get("launch", {}) or {}
@@ -70,11 +129,11 @@ def build_database(runs: list[dict], cur_path: str | None = None) -> duckdb.Duck
             "succeeded": stats.get("succeedCount", 0),
             "failed": stats.get("failedCount", 0),
             "cached": stats.get("cachedCount", 0),
-            "cpu_efficiency": prog.get("cpuEfficiency"),
-            "memory_efficiency": prog.get("memoryEfficiency"),
-            "cpu_time_ms": prog.get("cpuTime", 0),
-            "read_bytes": prog.get("readBytes", 0),
-            "write_bytes": prog.get("writeBytes", 0),
+            "cpu_efficiency": _first_present(prog, "cpuEfficiency"),
+            "memory_efficiency": _first_present(prog, "memoryEfficiency"),
+            "cpu_time_ms": _first_present(prog, "cpuTime", "cpuTimeMillis") or 0,
+            "read_bytes": _first_present(prog, "readBytes") or 0,
+            "write_bytes": _first_present(prog, "writeBytes") or 0,
             "fusion_enabled": fusion_enabled,
             "wave_enabled": bool(wf.get("wave", {}).get("enabled", False)) if wf.get("wave") else False,
             "command_line": wf.get("commandLine", ""),
@@ -1129,13 +1188,21 @@ app = typer.Typer(add_completion=False)
 
 @app.command()
 def main(
-    data_dir: Path = typer.Option(..., exists=True, help="Directory containing run JSON files"),
+    data_dir: Path | None = typer.Option(None, exists=True, help="Directory containing run JSON files"),
+    dump_dir: Path | None = typer.Option(None, exists=True, help="Directory containing unpacked run dump folders"),
     costs: Path | None = typer.Option(None, help="AWS CUR parquet file"),
     output: Path = typer.Option(Path("benchmark_report.html"), help="Output HTML file"),
     remove_failed: bool = typer.Option(True, help="Exclude failed tasks from analysis"),
 ) -> None:
     """Generate a benchmark report from Seqera Platform API data."""
-    runs = load_run_data(data_dir)
+    if dump_dir:
+        runs = load_run_dumps(dump_dir)
+    elif data_dir:
+        runs = load_run_data(data_dir)
+    else:
+        typer.echo("Provide either --data-dir or --dump-dir", err=True)
+        raise typer.Exit(code=1)
+
     if not runs:
         typer.echo("No run data found", err=True)
         raise typer.Exit(code=1)

--- a/main.nf
+++ b/main.nf
@@ -14,6 +14,7 @@
 */
 
 include { NF_AGGREGATE } from './workflows/nf_aggregate'
+include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nf_aggregate'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -36,12 +37,12 @@ workflow SEQERALABS_NF_AGGREGATE {
     //
     // SUBWORKFLOW: Run initialisation tasks
     //
-    // PIPELINE_INITIALISATION(
-    //     params.version,
-    //     params.validate_params,
-    //     params.outdir,
-    //     params.input,
-    // )
+    PIPELINE_INITIALISATION(
+        params.version,
+        params.validate_params,
+        params.outdir,
+        samplesheet,
+    )
 
     //
     // WORKFLOW: Run pipeline

--- a/modules/local/benchmark_report_v2/main.nf
+++ b/modules/local/benchmark_report_v2/main.nf
@@ -1,11 +1,12 @@
-// Benchmark report v2: Python + DuckDB + eCharts (replaces R/Quarto)
+// Benchmark report v2: Python + DuckDB + eCharts (compatible with existing run dumps)
 process BENCHMARK_REPORT_V2 {
 
-    conda 'python=3.12 duckdb=1.3 jinja2=3.1 click=8.1 pyarrow=18'
+    conda 'python=3.12 duckdb=1.3 jinja2=3.1 typer=0.12 pyarrow=18'
     container 'ghcr.io/seqeralabs/nf-agg:python-duckdb'
 
     input:
-    path data_dir
+    path run_dumps
+    val  groups
     path benchmark_aws_cur_report
 
     output:
@@ -15,8 +16,13 @@ process BENCHMARK_REPORT_V2 {
     script:
     def cost_flag = benchmark_aws_cur_report ? "--costs ${benchmark_aws_cur_report}" : ""
     """
+    mkdir -p run_dumps
+    ${run_dumps.withIndex().collect { run_dump, idx ->
+        "ln -s \$PWD/${run_dump} run_dumps/run_${idx}"
+    }.join('\n')}
+
     benchmark_report.py \\
-        --data-dir ${data_dir} \\
+        --dump-dir run_dumps \\
         ${cost_flag} \\
         --output benchmark_report.html
 

--- a/modules/local/benchmark_report_v2/nextflow.config
+++ b/modules/local/benchmark_report_v2/nextflow.config
@@ -1,9 +1,9 @@
 process {
-    withName: 'BENCHMARK_REPORT|BENCHMARK_REPORT_V2' {
+    withName: 'BENCHMARK_REPORT_V2' {
         publishDir = [
             path: { "${params.outdir}/benchmark_report" },
             mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') || filename.endsWith('.json') ? null : filename }
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
         containerOptions = "--user root"
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -322,7 +322,6 @@ manifest {
 // Nextflow plugins
 plugins {
     id 'nf-schema@2.3.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
-    id 'nf-boost@0.6.0'  // HTTP request(), fromJson/toJson, and other utilities
 }
 
 validation {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -75,6 +75,11 @@
                     "fa_icon": "fas fa-tachometer-alt",
                     "description": "Compile a benchmarking report for Seqera Platform runs."
                 },
+                "generate_benchmark_report_legacy": {
+                    "type": "boolean",
+                    "fa_icon": "fas fa-history",
+                    "description": "Generate the legacy Quarto/R benchmark report from existing run dumps."
+                },
                 "benchmark_aws_cur_report": {
                     "type": "string",
                     "fa_icon": "fas fa-dollar-sign",
@@ -132,6 +137,12 @@
                     "fa_icon": "fas fa-cog",
                     "hidden": true
                 },
+                "multiqc_title": {
+                    "type": "string",
+                    "description": "Custom title for the MultiQC report.",
+                    "fa_icon": "fas fa-heading",
+                    "hidden": true
+                },
                 "multiqc_logo": {
                     "type": "string",
                     "description": "Custom logo file to supply to MultiQC. File name must also be set in the MultiQC config file",
@@ -149,6 +160,11 @@
                     "type": "string",
                     "fa_icon": "far calendar",
                     "description": "Suffix to add to the trace report filename. Default is the date and time in the format yyyy-MM-dd_HH-mm-ss.",
+                    "hidden": true
+                },
+                "modules_testdata_base_path": {
+                    "type": "string",
+                    "description": "Base path for nf-core module test data.",
                     "hidden": true
                 }
             }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -109,7 +109,8 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"]
+                },
                 "max_multiqc_email_size": {
                     "type": "string",
                     "description": "File size limit when attaching MultiQC reports to summary emails.",

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -11,7 +11,6 @@ include { getProcessVersions     } from '../../subworkflows/local/utils_nf_aggre
 include { getWorkflowVersions    } from '../../subworkflows/local/utils_nf_aggregate'
 include { paramsSummaryMultiqc   } from '../../subworkflows/local/utils_nf_aggregate'
 include { paramsSummaryMap       } from 'plugin/nf-schema'
-include { request; fromJson; toJson } from 'plugin/nf-boost'
 
 workflow NF_AGGREGATE {
     take:
@@ -40,6 +39,7 @@ workflow NF_AGGREGATE {
         java_truststore_password ?: '',
     )
     ch_versions = ch_versions.mix(SEQERA_RUNS_DUMP.out.versions)
+    ch_all_run_dumps = SEQERA_RUNS_DUMP.out.run_dump.collect()
 
     //
     // MODULE: Generate Gantt chart for workflow execution
@@ -60,34 +60,17 @@ workflow NF_AGGREGATE {
     //
     if (params.generate_benchmark_report) {
         aws_cur_report = params.benchmark_aws_cur_report ? Channel.fromPath(params.benchmark_aws_cur_report) : []
-
-        // Fetch run data directly from Seqera API using nf-boost
-        ch_run_data = ids.map { meta ->
-            def data = SeqeraApi.fetchRunData(meta, seqera_api_endpoint)
-            data.meta = [id: meta.id, workspace: meta.workspace, group: meta.group ?: 'default']
-            return data
+        ch_benchmark_inputs = ch_all_run_dumps.map { runs ->
+            [
+                runs.collect { it[0] },
+                runs.collect { it[1] },
+            ]
         }
-
-        // Write each run's data to a JSON file, collect into one directory
-        ch_run_jsons = ch_run_data.map { data ->
-            def json_file = file("${workDir}/run_data/${data.meta.id}.json")
-            json_file.parent.mkdirs()
-            json_file.text = toJson(data)
-            return json_file
-        }
-
-        ch_data_dir = ch_run_jsons
-            .collect()
-            .map { files ->
-                def dir = file("${workDir}/benchmark_data")
-                dir.mkdirs()
-                files.each { f -> f.copyTo(dir.resolve(f.name)) }
-                return dir
-            }
 
         BENCHMARK_REPORT_V2(
-            ch_data_dir,
+            ch_benchmark_inputs,
             aws_cur_report,
+            params.remove_failed_tasks,
         )
         ch_versions = ch_versions.mix(BENCHMARK_REPORT_V2.out.versions)
     }
@@ -99,8 +82,8 @@ workflow NF_AGGREGATE {
         aws_cur_report_legacy = params.benchmark_aws_cur_report ? Channel.fromPath(params.benchmark_aws_cur_report) : []
 
         BENCHMARK_REPORT(
-            SEQERA_RUNS_DUMP.out.run_dump.collect { it[1] },
-            SEQERA_RUNS_DUMP.out.run_dump.collect { it[0].group },
+            ch_all_run_dumps.map { runs -> runs.collect { it[1] } },
+            ch_all_run_dumps.map { runs -> runs.collect { it[0].group ?: 'default' } },
             aws_cur_report_legacy,
             params.remove_failed_tasks,
         )
@@ -127,7 +110,7 @@ workflow NF_AGGREGATE {
         ch_workflow_summary = Channel.value(paramsSummaryMultiqc(summary_params))
         ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
         ch_multiqc_files = ch_multiqc_files.mix(ch_collated_versions)
-        ch_multiqc_files = ch_multiqc_files.mix(SEQERA_RUNS_DUMP.out.run_dump.collect { it[1] })
+        ch_multiqc_files = ch_multiqc_files.mix(ch_all_run_dumps.map { runs -> runs.collect { it[1] } })
 
         MULTIQC(
             ch_multiqc_files.collect(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore the top-level pipeline wiring so input initialization runs again
- keep `SEQERA_RUNS_DUMP` / tarball-based outputs as the canonical execution path and generate the new benchmark HTML from the unpacked run dumps instead of live nf-boost API calls
- add publish config for `BENCHMARK_REPORT_V2`, fix the invalid schema, and resolve the checked-in merge conflict in the PR template

## Testing
- ✅ `python3 -m json.tool nextflow_schema.json >/tmp/nfagg_schema_check.json`
- ✅ `python3 -m py_compile bin/benchmark_report.py`
- ✅ `nextflow config -flat > /tmp/nfagg_config_flat.txt`
- ✅ `python3 bin/benchmark_report.py --dump-dir /tmp/nfagg_sample_dumps --output /tmp/nfagg_benchmark_report.html`
- ✅ opened `/opt/cursor/artifacts/benchmark_report_demo.html` in Chrome and visually verified the rendered Benchmark overview / Run overview sections with `group1` and `group2`
- ⚠️ `nf-test test modules/local/benchmark_report/tests/main.nf.test` (fails in this cloud environment because `tw` is not available in the test runtime: `.command.sh: line 6: tw: command not found`)
- ⚠️ `nf-test test workflows/nf_aggregate/tests/main.nf.test` (same `tw` environment limitation)
- ⚠️ `nextflow run . -profile test,docker -stub-run --outdir /tmp/nfagg-stub-2` (now starts successfully on Nextflow 24.10.4, but still hits an existing `SEQERA_RUNS_DUMP` stub-run null-clone failure unrelated to the benchmark path)

## Walkthrough
[benchmark_report_desktop_demo.mp4](https://cursor.com/agents/bc-d9e5c70a-d3ff-4bb5-a62b-58f9b6c92270/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbenchmark_report_desktop_demo.mp4)
Benchmark report HTML opens and renders on the desktop.

[benchmark report header and overview](https://cursor.com/agents/bc-d9e5c70a-d3ff-4bb5-a62b-58f9b6c92270/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbenchmark_report_header.webp)
[benchmark report run overview](https://cursor.com/agents/bc-d9e5c70a-d3ff-4bb5-a62b-58f9b6c92270/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbenchmark_report_run_overview.webp)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9e5c70a-d3ff-4bb5-a62b-58f9b6c92270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9e5c70a-d3ff-4bb5-a62b-58f9b6c92270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

