### PR TITLE
Add Cursor Cloud specific development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,3 +54,74 @@ uv run --with duckdb --with typer --with pyyaml --with httpx \
 - DuckDB `read_json_auto` needs file paths, not JSON strings — use temp files
 - `commit.gpgsign` must be true (SSH signing via 1Password)
 - RTK `buildOutputFiltering` / `testOutputAggregation` can swallow nf-test output — disable to debug
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Purpose | Run command |
+|---------|---------|-------------|
+| Nextflow pipeline | Core product — aggregates metrics from Seqera Platform runs | `nextflow run . --input <csv> --outdir results -profile docker` |
+| Python benchmark_report.py | Builds DuckDB + renders HTML report | See "Rebuild Command" section above |
+
+### Running tests
+
+- **pytest (Python unit tests):** `uv run --with duckdb --with typer --with pyyaml --with jinja2 --with pyarrow --with pytest --with httpx pytest bin/test_benchmark_report.py -v`
+- **nf-test (pipeline integration tests):** `nf-test test --profile=+docker --verbose`
+- **Lint:** `pre-commit run --all-files`
+
+### Docker in Cloud VM (cgroupv2 workaround)
+
+The Cloud VM runs inside a Firecracker VM where the root cgroupv2 hierarchy cannot delegate `memory`/`io` controllers. Docker containers that request resource limits (`--memory`, `--cpu-shares` — used by Nextflow's `process { memory; cpus }`) will fail with `"cannot enter cgroupv2 ... with domain controllers"`.
+
+**Workaround:** A `runc` wrapper at `/usr/bin/runc` strips `linux.resources` from the OCI spec before passing to the real runtime at `/usr/bin/runc.real`. This is already set up in the VM snapshot. If Docker container launches fail with cgroup errors after a fresh setup, re-apply:
+
+```bash
+# Ensure /usr/bin/runc.real exists (backup of original runc)
+sudo cp /usr/bin/runc /usr/bin/runc.real 2>/dev/null || true
+# Install wrapper
+cat > /tmp/runc-wrapper.sh << 'WRAPPER'
+#!/bin/bash
+for arg in "$@"; do
+    if [ "$arg" = "create" ]; then
+        bundle_dir=""
+        next_is_bundle=false
+        for a in "$@"; do
+            if $next_is_bundle; then bundle_dir="$a"; break; fi
+            if [ "$a" = "--bundle" ] || [ "$a" = "-b" ]; then next_is_bundle=true; fi
+        done
+        if [ -n "$bundle_dir" ] && [ -f "$bundle_dir/config.json" ]; then
+            python3 -c "
+import json
+with open('$bundle_dir/config.json') as f: config = json.load(f)
+if 'linux' in config and 'resources' in config['linux']: del config['linux']['resources']
+with open('$bundle_dir/config.json', 'w') as f: json.dump(config, f)
+" 2>/dev/null
+        fi
+        break
+    fi
+done
+exec /usr/bin/runc.real "$@"
+WRAPPER
+chmod +x /tmp/runc-wrapper.sh
+sudo cp /tmp/runc-wrapper.sh /usr/bin/runc
+```
+
+### Running the pipeline without TOWER_ACCESS_TOKEN
+
+The default test profile CSV references API runs requiring `TOWER_ACCESS_TOKEN`. For offline testing, use the external tarball fixtures:
+
+```bash
+nextflow run . --input workflows/nf_aggregate/assets/test_benchmark.csv \
+  --generate_benchmark_report --outdir results -profile docker
+```
+
+### Docker daemon startup
+
+Docker must be started manually in the Cloud VM:
+
+```bash
+sudo dockerd &>/tmp/dockerd.log &
+sleep 3
+sudo chmod 666 /var/run/docker.sock
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `## Cursor Cloud specific instructions` section to `AGENTS.md` with development environment guidance for future cloud agents.

### Changes

- Document Docker cgroupv2 workaround (runc wrapper) needed in Cloud VM Firecracker environment
- Add test commands: pytest, nf-test, pre-commit lint
- Document offline pipeline testing with external tarball fixtures (no `TOWER_ACCESS_TOKEN` needed)
- Add Docker daemon startup instructions for Cloud VM

### Testing evidence

All tests pass in the Cloud VM environment:

**pytest (107 passed, 3 skipped):**
[pytest_output.log](https://cursor.com/agents/bc-fc95d421-f508-45d4-8b5a-3208cc74fd08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpytest_output.log)

**nf-test (4/4 passed):**
[nftest_output.log](https://cursor.com/agents/bc-fc95d421-f508-45d4-8b5a-3208cc74fd08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnftest_output.log)

**Pipeline run producing benchmark report:**
The pipeline was run with `nextflow run . --input workflows/nf_aggregate/assets/test_benchmark.csv --generate_benchmark_report --outdir results -profile docker` and successfully generated `benchmark.duckdb` and `benchmark_report.html`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, parameter, or workflow path, update the relevant docs.
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc95d421-f508-45d4-8b5a-3208cc74fd08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc95d421-f508-45d4-8b5a-3208cc74fd08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

