### PR TITLE
fix(ci): restore lint workflow on dev; document private CA for Platform

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,7 +1,5 @@
-name: nf-core linting
-# This workflow is triggered on pushes and PRs to the repository.
-# It runs the `nf-core pipelines lint` and markdown lint tests to ensure
-# that the code meets the nf-core guidelines.
+name: Pipeline linting
+# Runs pre-commit (Prettier, editorconfig, etc.) on pushes to dev and on pull requests.
 on:
   push:
     branches:
@@ -26,58 +24,3 @@ jobs:
 
       - name: Run pre-commit
         run: pre-commit run --all-files
-
-  nf-core:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out pipeline code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - name: Install Nextflow
-        uses: nf-core/setup-nextflow@v2
-
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: "3.12"
-          architecture: "x64"
-
-      - name: read .nf-core.yml
-        uses: pietrobolcato/action-read-yaml@1.1.0
-        id: read_yml
-        with:
-          config: ${{ github.workspace }}/.nf-core.yml
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install nf-core==${{ steps.read_yml.outputs['nf_core_version'] }}
-
-      - name: Run nf-core pipelines lint
-        if: ${{ github.base_ref != 'master' }}
-        env:
-          GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
-        run: nf-core -l lint_log.txt pipelines lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
-
-      - name: Run nf-core pipelines lint --release
-        if: ${{ github.base_ref == 'master' }}
-        env:
-          GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
-        run: nf-core -l lint_log.txt pipelines lint --release --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
-
-      - name: Save PR number
-        if: ${{ always() }}
-        run: echo ${{ github.event.pull_request.number }} > PR_number.txt
-
-      - name: Upload linting log file artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
-        with:
-          name: linting-logs
-          path: |
-            lint_log.txt
-            lint_results.md
-            PR_number.txt

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,5 @@ testing/
 testing*
 *.pyc
 bin/
+# Large single-line fixture JSON (Prettier would expand to thousands of lines)
+workflows/nf_aggregate/assets/log_dirs/**/*.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,10 +66,10 @@ uv run --with typer --with pyyaml \
 
 ### Services overview
 
-| Service | Purpose | Run command |
-|---------|---------|-------------|
-| Nextflow pipeline | Core product — aggregates metrics from Seqera Platform runs | `nextflow run . --input <csv> --outdir results -profile docker` |
-| Python benchmark_report.py | Normalizes JSON -> JSONL, aggregates report data, then renders HTML | See "Rebuild Command" section above |
+| Service                    | Purpose                                                             | Run command                                                     |
+| -------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Nextflow pipeline          | Core product — aggregates metrics from Seqera Platform runs         | `nextflow run . --input <csv> --outdir results -profile docker` |
+| Python benchmark_report.py | Normalizes JSON -> JSONL, aggregates report data, then renders HTML | See "Rebuild Command" section above                             |
 
 ### Running tests
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The pipeline fetches run data from the Seqera Platform API and generates benchma
 
 - [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#installation) >=25.10.0
 - Account in [Seqera Platform](https://seqera.io/platform/)
-- [Access token](https://docs.seqera.io/platform/23.3.0/api/overview#authentication) which is your personal authorization token for the Seqera Platform CLI. This can be created in the user menu under **Your tokens**. Export the token as a shell variable directly into your terminal if running the pipelie locally. You will not need to set this if running the pipeline within the Seqera Platform as it will automatically be inherited from the executing environment.
+- [Access token](https://docs.seqera.io/platform/23.3.0/api/overview#authentication) which is your personal authorization token for the Seqera Platform CLI. This can be created in the user menu under **Your tokens**. Export the token as a shell variable directly into your terminal if running the pipeline locally. You will not need to set this if running the pipeline within the Seqera Platform as it will automatically be inherited from the executing environment.
 
   ```bash
   export TOWER_ACCESS_TOKEN=<your access token>
@@ -46,7 +46,25 @@ nextflow run seqeralabs/nf-aggregate \
     -profile docker
 ```
 
-If you are using a Seqera Platform Enterprise instance that is secured with a private CA SSL certificate not recognized by default Java certificate authorities, you can specify a custom `cacerts` store path through the `--java_truststore_path` parameter and optionally, a password with the `--java_truststore_password`. This certificate will be used to achieve connectivity with your Seqera Platform instance through API and CLI.
+If you are using a Seqera Platform Enterprise instance that is secured with a private CA SSL certificate not recognized by default Java certificate authorities, you can specify a custom `cacerts` store path through the `--java_truststore_path` parameter and optionally, a password with the `--java_truststore_password`. This configures the Nextflow JVM used for Seqera Platform API access (see `lib/SeqeraApi.groovy`).
+
+### Seqera Platform Enterprise with a private CA (containers)
+
+For API access from Nextflow, `--java_truststore_path` / `--java_truststore_password` are usually sufficient. Task containers may still lack your private CA when they open TLS connections. As a workaround, add the following under **Advanced options → Nextflow config** in Seqera Platform (replace `tower-server-url` with your Seqera host name only, without `https://`):
+
+```groovy
+process {
+   withName: /NORMALIZE_BENCHMARK_JSONL|AGGREGATE_BENCHMARK_REPORT_DATA|RENDER_BENCHMARK_REPORT|EXTRACT_TARBALL/ {
+     beforeScript = '''
+keytool -printcert -rfc -sslserver tower-server-url:443 > PRIVATE_CERT.pem
+keytool -importcert -alias seqera-ca -file PRIVATE_CERT.pem -keystore truststore.jks -storepass changeit -noprompt
+export JAVA_TOOL_OPTIONS="-Djavax.net.ssl.trustStore=$(pwd)/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit"
+'''
+   }
+}
+```
+
+This downloads the server certificate, builds a small JKS truststore in the task work directory, and points the JVM inside the task at it.
 
 ### Benchmark reports
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -36,6 +36,7 @@ python bin/benchmark_report.py normalize-jsonl --data-dir <run_json_dir> --outpu
 ```
 
 Responsibilities:
+
 - read run JSON payloads
 - normalize runs/tasks/metrics rows
 - optionally normalize CUR parquet into `costs.jsonl`
@@ -54,6 +55,7 @@ python bin/benchmark_report.py aggregate-report-data --jsonl-dir <jsonl_bundle> 
 ```
 
 Responsibilities:
+
 - stream JSONL rows
 - compute report sections:
   - `benchmark_overview`
@@ -75,6 +77,7 @@ python bin/benchmark_report.py render-html --data <report_data.json> --output <b
 ```
 
 Responsibilities:
+
 - load report JSON
 - apply brand/logo overrides when provided
 - render self-contained HTML from the Jinja template
@@ -82,6 +85,7 @@ Responsibilities:
 ## Benchmark CLI surface
 
 `bin/benchmark_report.py` provides:
+
 - `normalize-jsonl`
 - `aggregate-report-data`
 - `render-html`

--- a/main.nf
+++ b/main.nf
@@ -13,17 +13,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-include { NF_AGGREGATE         } from './workflows/nf_aggregate'
-include {
-    checkCondaChannels ;
-    dumpParametersToJSON ;
-    getWorkflowVersion
-} from 'plugin/nf-core-utils'
-include {
-    paramsSummaryLog ;
-    samplesheetToList ;
-    validateParameters
-} from 'plugin/nf-schema'
+include { NF_AGGREGATE } from './workflows/nf_aggregate'
+include { checkCondaChannels ; dumpParametersToJSON ; getWorkflowVersion } from 'plugin/nf-core-utils'
+include { paramsSummaryLog ; samplesheetToList ; validateParameters } from 'plugin/nf-schema'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/modules/local/AGENTS.md
+++ b/modules/local/AGENTS.md
@@ -2,13 +2,14 @@
 
 Each module should keep one clear responsibility and its own terse `AGENTS.md`.
 
-| Module                                  | Status     | Purpose                                        |
-| --------------------------------------- | ---------- | ---------------------------------------------- |
-| `normalize_benchmark_jsonl/`            | **active** | Raw run JSON (+ optional CUR parquet) → JSONL |
-| `aggregate_benchmark_report_data/`      | **active** | JSONL bundle → `report_data.json`              |
-| `render_benchmark_report/`              | **active** | `report_data.json` + branding → HTML           |
-| `extract_tarball/`                      | active     | Extract run-data tarballs for external runs    |
+| Module                             | Status     | Purpose                                       |
+| ---------------------------------- | ---------- | --------------------------------------------- |
+| `normalize_benchmark_jsonl/`       | **active** | Raw run JSON (+ optional CUR parquet) → JSONL |
+| `aggregate_benchmark_report_data/` | **active** | JSONL bundle → `report_data.json`             |
+| `render_benchmark_report/`         | **active** | `report_data.json` + branding → HTML          |
+| `extract_tarball/`                 | active     | Extract run-data tarballs for external runs   |
 
 Testing
+
 - Keep stage-specific pytest tests beside the module under `tests/`.
 - Keep pipeline routing/integration scenarios under top-level `tests/`.

--- a/modules/local/aggregate_benchmark_report_data/AGENTS.md
+++ b/modules/local/aggregate_benchmark_report_data/AGENTS.md
@@ -1,21 +1,26 @@
 # aggregate_benchmark_report_data
 
 Purpose
+
 - Convert the JSONL bundle into a single `report_data.json` document for rendering.
 
 Owns
+
 - `AGGREGATE_BENCHMARK_REPORT_DATA` in `main.nf`
 - Python aggregation logic in `bin/benchmark_report_aggregate.py`
 - Stage-scoped tests under `tests/`
 
 Inputs
+
 - `jsonl_bundle/` from `normalize_benchmark_jsonl`
 
 Outputs
+
 - `report_data.json`
 - `versions.yml`
 
 Invariants
+
 - This is the boundary between streaming records and presentation data.
 - Prefer streaming iteration over JSONL inputs; avoid full-file eager loads unless clearly bounded.
 - Cost joins must key by `(run_id, process, hash)` to avoid cross-process collisions.
@@ -31,8 +36,10 @@ Invariants
   - `cost_overview`
 
 Edit guidance
+
 - Keep rendering/template logic out of this stage.
 - If output schema changes, update render tests and any HTML assertions.
 
 Tests
+
 - `pytest modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py -q`

--- a/modules/local/extract_tarball/AGENTS.md
+++ b/modules/local/extract_tarball/AGENTS.md
@@ -1,21 +1,27 @@
 # extract_tarball
 
 Purpose
+
 - Extract external run-data tarballs into directories of JSON artifacts.
 
 Owns
+
 - `EXTRACT_TARBALL` in `main.nf`
 
 Inputs
+
 - external tarball paths from the workflow routing layer
 
 Outputs
+
 - extracted directory per tarball
 - `versions.yml`
 
 Invariants
+
 - Extraction only. Do not mix benchmark parsing or aggregation into this module.
 - Downstream workflow code is responsible for collecting JSON files from extracted directories.
 
 Edit guidance
+
 - If tarball layout assumptions change, update the pipeline tarball scenario tests.

--- a/modules/local/normalize_benchmark_jsonl/AGENTS.md
+++ b/modules/local/normalize_benchmark_jsonl/AGENTS.md
@@ -1,18 +1,22 @@
 # normalize_benchmark_jsonl
 
 Purpose
+
 - Normalize collected run JSON into a stream-friendly `jsonl_bundle/`.
 
 Owns
+
 - `NORMALIZE_BENCHMARK_JSONL` in `main.nf`
 - Python stage logic in `bin/benchmark_report_normalize.py`
 - Stage-scoped tests under `tests/`
 
 Inputs
+
 - `data_dir/` of per-run JSON payloads
 - optional CUR parquet
 
 Outputs
+
 - `jsonl_bundle/runs.jsonl`
 - `jsonl_bundle/tasks.jsonl`
 - `jsonl_bundle/metrics.jsonl`
@@ -20,12 +24,14 @@ Outputs
 - `versions.yml`
 
 Invariants
+
 - JSONL is the handoff format for Fusion-friendly streaming.
 - One JSON object per line.
 - Task rows should already include derived fields needed downstream (`process_short`, `wait_ms`, `staging_ms`).
 - Failed tasks are filtered here so downstream stages stay simple.
 
 Edit guidance
+
 - Keep this stage about normalization only; no report aggregation or HTML concerns.
 - If you change row shape, update:
   - `bin/benchmark_report_normalize.py`
@@ -33,4 +39,5 @@ Edit guidance
   - any CLI compatibility tests affected
 
 Tests
+
 - `pytest modules/local/normalize_benchmark_jsonl/tests/test_normalize.py -q`

--- a/modules/local/render_benchmark_report/AGENTS.md
+++ b/modules/local/render_benchmark_report/AGENTS.md
@@ -1,30 +1,37 @@
 # render_benchmark_report
 
 Purpose
+
 - Render self-contained HTML from `report_data.json` plus branding assets.
 
 Owns
+
 - `RENDER_BENCHMARK_REPORT` in `main.nf`
 - Python render logic in `bin/benchmark_report_render.py`
 - Stage-scoped tests under `tests/`
 
 Inputs
+
 - `report_data.json`
 - optional `brand.yml`
 - optional logo SVG
 
 Outputs
+
 - `benchmark_report.html`
 - `versions.yml`
 
 Invariants
+
 - Rendering consumes precomputed report data only.
 - No raw JSON normalization or report aggregation should happen here.
 - Keep template input contract stable unless you also update the renderer tests and report template.
 
 Edit guidance
+
 - Prefer changing `report_data.json` upstream over adding data-massaging logic in the template.
 - Branding/theme lookup should stay tolerant of missing optional assets.
 
 Tests
+
 - `pytest modules/local/render_benchmark_report/tests/test_render.py -q`

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "baseBranches": ["dev"]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "baseBranches": ["dev"]
 }

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,6 +1,7 @@
 # tests/
 
 ## Layout
+
 Each pipeline-level scenario lives in its own directory:
 
 - `pipeline_api_only/`
@@ -9,11 +10,13 @@ Each pipeline-level scenario lives in its own directory:
 - `pipeline_benchmark_directory/`
 
 Each scenario directory contains:
+
 - `main.nf.test` — the nf-test scenario
 - `main.nf.test.snap` — the snapshot for that scenario
 - `AGENTS.md` — scenario-specific guidance for future edits
 
 ## Conventions
+
 - One scenario per directory.
 - Keep assertions local and explicit rather than heavily abstracted.
 - Prefer stable fixture files under `workflows/nf_aggregate/assets/`.
@@ -21,6 +24,7 @@ Each scenario directory contains:
 - This directory is for pipeline routing/integration scenarios only; stage-specific pytest tests now live beside the relevant module under `modules/local/*/tests/`.
 
 ## Running tests
+
 Run all pipeline-level scenario tests with:
 
 ```bash

--- a/tests/pipeline_api_only/AGENTS.md
+++ b/tests/pipeline_api_only/AGENTS.md
@@ -1,16 +1,20 @@
 # pipeline_api_only
 
 ## Purpose
+
 Covers the API-only input path when `generate_benchmark_report` is disabled.
 
 ## Fixtures
+
 - `workflows/nf_aggregate/assets/test_run_ids.csv`
 
 ## Expected behavior
+
 - No Nextflow processes should run.
 - A warning should explain that API runs produce no output without benchmark generation.
 - Only `pipeline_info/collated_software_versions.yml` should be emitted.
 - No `benchmark_report/` directory should exist.
 
 ## Edit guidance
+
 If you change API-only routing, benchmark gating, or warning text, update this test first.

--- a/tests/pipeline_benchmark_directory/AGENTS.md
+++ b/tests/pipeline_benchmark_directory/AGENTS.md
@@ -1,13 +1,16 @@
 # pipeline_benchmark_directory
 
 ## Purpose
+
 Covers benchmark generation when external logs are provided as an already-extracted directory.
 
 ## Fixtures
+
 - `workflows/nf_aggregate/assets/test_benchmark_directory.csv`
 - JSON fixture directory under `workflows/nf_aggregate/assets/log_dirs/`
 
 ## Expected behavior
+
 - `EXTRACT_TARBALL` must not run.
 - Benchmark stages should consume the directory directly:
   - `NORMALIZE_BENCHMARK_JSONL`
@@ -17,4 +20,5 @@ Covers benchmark generation when external logs are provided as an already-extrac
 - The rendered HTML should mention the expected run ID and group.
 
 ## Edit guidance
+
 If you change support for directory-based external logs, update this test first.

--- a/tests/pipeline_benchmark_tarball/AGENTS.md
+++ b/tests/pipeline_benchmark_tarball/AGENTS.md
@@ -1,13 +1,16 @@
 # pipeline_benchmark_tarball
 
 ## Purpose
+
 Covers benchmark generation when external logs are supplied as tarballs.
 
 ## Fixtures
+
 - `workflows/nf_aggregate/assets/test_benchmark.csv`
 - tarballs under `workflows/nf_aggregate/assets/logs/`
 
 ## Expected behavior
+
 - `EXTRACT_TARBALL` should run for each external input.
 - Benchmark stages should run once after collection:
   - `NORMALIZE_BENCHMARK_JSONL`
@@ -17,4 +20,5 @@ Covers benchmark generation when external logs are supplied as tarballs.
 - The rendered HTML should mention the expected run IDs and groups.
 
 ## Edit guidance
+
 If you change tarball extraction, benchmark aggregation, or HTML report content, update this test.

--- a/tests/pipeline_mixed_no_benchmark/AGENTS.md
+++ b/tests/pipeline_mixed_no_benchmark/AGENTS.md
@@ -1,16 +1,20 @@
 # pipeline_mixed_no_benchmark
 
 ## Purpose
+
 Covers mixed input routing when benchmark generation is disabled.
 
 ## Fixtures
+
 - `workflows/nf_aggregate/assets/test_mixed_no_benchmark.csv`
 
 ## Expected behavior
+
 - API rows should be skipped with a warning.
 - External tarball rows should still run through `EXTRACT_TARBALL`.
 - Benchmark stages must not run (`NORMALIZE_BENCHMARK_JSONL`, `AGGREGATE_BENCHMARK_REPORT_DATA`, `RENDER_BENCHMARK_REPORT`).
 - No `benchmark_report/` output should exist.
 
 ## Edit guidance
+
 If you change branching logic between API and external logs, or benchmark gating for mixed inputs, update this test.

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -33,7 +33,7 @@ workflow NF_AGGREGATE {
         ch_split.api.count().subscribe { n ->
             if (n > 0) {
                 log.warn "Found ${n} API run(s) but --generate_benchmark_report is not enabled. " +
-                         "API runs will not produce any output. Enable --generate_benchmark_report to process them."
+                    "API runs will not produce any output. Enable --generate_benchmark_report to process them."
             }
         }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`dev` removed `.nf-core.yml` in `ca70336` while keeping a lint workflow that still ran `nf-core pipelines lint` and read that file. Pushes to `dev` failed (missing config, broken `pip install nf-core==`).

This PR:

- Simplifies `.github/workflows/linting.yml` to **pre-commit only**, which matches the current repo (no `.nf-core.yml`).
- Keeps the pinned `actions/checkout` and `actions/setup-python` versions already on `dev` (same intent as open Renovate PRs #114 / #116).
- Adds README documentation for **private CA** on Seqera Platform Enterprise: clarifies `--java_truststore_*` for the Nextflow/API JVM and documents an optional `beforeScript` pattern for **task containers**, using current process names (`NORMALIZE_BENCHMARK_JSONL`, etc.) instead of the old `SEQERA_RUNS_DUMP` name from #99.
- Fixes **editorconfig** continuation indent in `workflows/nf_aggregate/main.nf`.
- **Pre-commit:** formats `AGENTS.md` / `docs/DESIGN.md` / `renovate.json` to match Prettier (CI was failing on `dev` for PRs); adds `.prettierignore` for large one-line fixture JSON under `workflows/nf_aggregate/assets/log_dirs/`.
- **CI:** collapses multi-line `include { ... } from 'plugin/...'` blocks in `main.nf` to single lines so `adamrtalbot/detect-nf-test-changes@v0.0.3` does not crash on PRs.

## Supersedes / relates to open PRs

- **#114 / #116**: Dependency bumps are already present on `dev`; close those against `main` in favor of this branch once merged.
- **#99**: Content ported in spirit; external fork branch is stale—close after this merges if satisfied.

## Testing

- `pre-commit run --all-files`
- Full nf-test with Docker was not run in this environment (no Docker socket).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab90a1ca-cc0c-46a5-a43d-83e533386d6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab90a1ca-cc0c-46a5-a43d-83e533386d6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

