### PR TITLE
chore(ci): update nf-test checkout pin

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -48,7 +48,7 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
           ls -la ./
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -91,7 +91,7 @@ jobs:
       TOTAL_SHARDS: ${{ needs.nf-test-changes.outputs.total_shards }}
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- rebases the abandoned `#114` Renovate change onto current `dev`
- updates the two `actions/checkout` pins in `.github/workflows/nf-test.yml` to `v4.3.1`
- validates the rebased change with the repo's prescribed pytest, `nf-test`, and offline Nextflow benchmark-report run

## Walkthrough
[pr114_benchmark_report_walkthrough.mp4](https://cursor.com/agents/bc-cd38b7c7-7765-4d02-822f-ed9c873a0aa5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr114_benchmark_report_walkthrough.mp4)

[Benchmark report overview](https://cursor.com/agents/bc-cd38b7c7-7765-4d02-822f-ed9c873a0aa5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr114_report_overview.webp)
[Benchmark report metrics](https://cursor.com/agents/bc-cd38b7c7-7765-4d02-822f-ed9c873a0aa5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr114_report_metrics.webp)
[Benchmark report process overview](https://cursor.com/agents/bc-cd38b7c7-7765-4d02-822f-ed9c873a0aa5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr114_report_process_overview.webp)

[pr114_compiled_test_report.md](https://cursor.com/agents/bc-cd38b7c7-7765-4d02-822f-ed9c873a0aa5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpr114_compiled_test_report.md)

## Testing
- `uv run --with typer --with pyyaml --with jinja2 --with pyarrow --with pytest --with httpx pytest -v modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py modules/local/normalize_benchmark_jsonl/tests/test_normalize.py modules/local/render_benchmark_report/tests/test_render.py bin/test_benchmark_report_fetch.py`
- `nf-test test --profile=+docker --verbose`
- `nextflow run . --input workflows/nf_aggregate/assets/test_benchmark.csv --generate_benchmark_report --outdir /tmp/nf-aggregate-e2e-results -profile docker`

## PR checklist
- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool, parameter, or workflow path, update the relevant docs.
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd38b7c7-7765-4d02-822f-ed9c873a0aa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd38b7c7-7765-4d02-822f-ed9c873a0aa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

