### PR TITLE
Add scheduler VM metrics to benchmark reports

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -52,9 +52,9 @@ These tests are run both with the latest available version of `Nextflow` and als
 
 :warning: Only in the unlikely and regretful event of a release happening with a bug.
 
-- On your own fork, make a new branch `patch` based on `upstream/main` or `upstream/master`.
+- On your own fork, make a new branch `patch` based on `upstream/dev`.
 - Fix the bug, and bump version (X.Y.Z+1).
-- Open a pull-request from `patch` to `main`/`master` with the changes.
+- Open a pull-request from `patch` to `dev` with the changes.
 
 ## Pipeline contribution conventions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
     outputs:
       nf_test_files: ${{ steps.list.outputs.components }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
 
       - name: List nf-test files
         id: list
-        uses: adamrtalbot/detect-nf-test-changes@v0.0.3
+        uses: adamrtalbot/detect-nf-test-changes@6e67b7a6bd3caf8571b99cab3ab764c0e758f55c # v0.0.3
         with:
           head: ${{ github.sha }}
           base: origin/${{ github.base_ref }}
@@ -62,14 +62,14 @@ jobs:
 
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Nextflow
-        uses: nf-core/setup-nextflow@v2
+        uses: nf-core/setup-nextflow@6c2e22b4d901f0c42ca66c5069f8026df026d165 # v2
         with:
           version: "${{ matrix.NXF_VER }}"
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.11"
           architecture: "x64"
@@ -81,7 +81,7 @@ jobs:
 
       - name: Cache nf-test installation
         id: cache-software
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: |
             /usr/local/bin/nf-test
@@ -98,7 +98,7 @@ jobs:
         run: |
           nf-test test --verbose ${{ matrix.nf_test_files }} --profile "+${{ matrix.profile }}" --junitxml=test.xml --tap=test.tap
 
-      - uses: pcolby/tap-summary@v1
+      - uses: pcolby/tap-summary@3f74dc3bad1d527b8c1d5fa88e2f72a3adb2d9e6 # v1
         with:
           path: >-
             test.tap
@@ -110,7 +110,7 @@ jobs:
           batcat --decorations=always --color=always ${{ github.workspace }}/.nf-test/tests/*/meta/nextflow.log
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@150e2f992e4fad1379da2056d1d1c279f520e058 # v3
         if: always() # always run even if the previous step fails
         with:
           report_paths: test.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
     outputs:
       nf_test_files: ${{ steps.list.outputs.components }}
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: List nf-test files
         id: list
-        uses: adamrtalbot/detect-nf-test-changes@6e67b7a6bd3caf8571b99cab3ab764c0e758f55c # v0.0.3
+        uses: adamrtalbot/detect-nf-test-changes@v0.0.3
         with:
           head: ${{ github.sha }}
           base: origin/${{ github.base_ref }}
@@ -62,14 +62,14 @@ jobs:
 
     steps:
       - name: Check out pipeline code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
 
       - name: Install Nextflow
-        uses: nf-core/setup-nextflow@6c2e22b4d901f0c42ca66c5069f8026df026d165 # v2
+        uses: nf-core/setup-nextflow@v2
         with:
           version: "${{ matrix.NXF_VER }}"
 
-      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
           architecture: "x64"
@@ -81,7 +81,7 @@ jobs:
 
       - name: Cache nf-test installation
         id: cache-software
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+        uses: actions/cache@v3
         with:
           path: |
             /usr/local/bin/nf-test
@@ -98,7 +98,7 @@ jobs:
         run: |
           nf-test test --verbose ${{ matrix.nf_test_files }} --profile "+${{ matrix.profile }}" --junitxml=test.xml --tap=test.tap
 
-      - uses: pcolby/tap-summary@3f74dc3bad1d527b8c1d5fa88e2f72a3adb2d9e6 # v1
+      - uses: pcolby/tap-summary@v1
         with:
           path: >-
             test.tap
@@ -110,7 +110,7 @@ jobs:
           batcat --decorations=always --color=always ${{ github.workspace }}/.nf-test/tests/*/meta/nextflow.log
 
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@150e2f992e4fad1379da2056d1d1c279f520e058 # v3
+        uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails
         with:
           report_paths: test.xml

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
 
       - name: Install Nextflow
-        uses: nf-core/setup-nextflow@v2
+        uses: nf-core/setup-nextflow@6c2e22b4d901f0c42ca66c5069f8026df026d165 # v2
 
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
@@ -42,7 +42,7 @@ jobs:
           architecture: "x64"
 
       - name: read .nf-core.yml
-        uses: pietrobolcato/action-read-yaml@1.1.0
+        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d # 1.1.0
         id: read_yml
         with:
           config: ${{ github.workspace }}/.nf-core.yml

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
 
       - name: Install Nextflow
-        uses: nf-core/setup-nextflow@6c2e22b4d901f0c42ca66c5069f8026df026d165 # v2
+        uses: nf-core/setup-nextflow@v2
 
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
         with:
@@ -42,7 +42,7 @@ jobs:
           architecture: "x64"
 
       - name: read .nf-core.yml
-        uses: pietrobolcato/action-read-yaml@9f13718d61111b69f30ab4ac683e67a56d254e1d # 1.1.0
+        uses: pietrobolcato/action-read-yaml@1.1.0
         id: read_yml
         with:
           config: ${{ github.workspace }}/.nf-core.yml

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ If you are using a Seqera Platform Enterprise instance that is secured with a pr
 
 If you want to generate a benchmark report comparing multiple runs, you can include a `group` column in your `run_ids.csv` file. This allows you to organize and analyze runs based on custom groupings in the final report.
 
+If you also have per-run machine CSVs, you can provide them with an optional `machines` column. When present, the benchmark report adds scheduler and VM capacity metrics such as total machine-hours, scheduler allocation efficiency, and real VM efficiency derived from the task logs.
+
 ```
 id,workspace,group
 3VcLMAI8wyy0Ld,community/showcase,group1
@@ -71,15 +73,15 @@ id,workspace,group
 
 ## Use logs from an external Seqera Platform deployment
 
-Sometimes we want to compile benchmark reports from runs from two different Seqera platform deployments, for example a dev and a production environment to compare performance. External logs in nf-aggregate can be used by specifying the workspace as `external` and providing some additional optional columns that point to the log folder and specify whether these external logs contain fusion logs (did you export them with the `--add-fusion-logs` flag in your `tw run dumps`. If they do contain fusion logs, you can generate a gannt plot for them, as for runs supplied only via id.)
+Sometimes we want to compile benchmark reports from runs from two different Seqera platform deployments, for example a dev and a production environment to compare performance. External logs in nf-aggregate can be used by specifying the workspace as `external` and providing some additional optional columns that point to the log folder and specify whether these external logs contain fusion logs (did you export them with the `--add-fusion-logs` flag in your `tw run dumps`. If they do contain fusion logs, you can generate a gannt plot for them, as for runs supplied only via id.) You can also optionally provide a `machines` column that points to a machine metrics CSV for the same run.
 
 Here is an example of using a mix of run ids for which we want to extract logs from our platform deployment and some run logs from another deployment we want to compare. In the example below, `1JI5B1avuj3o58` is a run that contains fusion logs, while `1vsww7GjKBsVNa` does not contain fusion logs.
 
 ```
-id,workspace,group,logs,fusion
-3VcLMAI8wyy0Ld,community/showcase,group1,
-1JI5B1avuj3o58,external,group2,/path/to/my/run_dumps_tarball.tar.gz,true
-1vsww7GjKBsVNa,external,group2,/path/to/my/run_dumps_folder,false
+id,workspace,group,logs,fusion,machines
+3VcLMAI8wyy0Ld,community/showcase,group1,,,
+1JI5B1avuj3o58,external,group2,/path/to/my/run_dumps_tarball.tar.gz,true,/path/to/my/machines.csv
+1vsww7GjKBsVNa,external,group2,/path/to/my/run_dumps_folder,false,
 ```
 
 ## Incorporate AWS split cost allocation data

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -32,6 +32,13 @@
                 "errorMessage": "Please provide a valid file path to your Seqera Platform logs.",
                 "meta": ["logs"]
             },
+            "machines": {
+                "type": "string",
+                "format": "file-path",
+                "pattern": "^\\S+$",
+                "errorMessage": "Please provide a valid file path to your machine metrics CSV.",
+                "meta": ["machines"]
+            },
             "fusion": {
                 "type": "boolean",
                 "meta": ["fusion"]

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -4,7 +4,8 @@ process BENCHMARK_REPORT {
 
     input:
     path run_dumps
-    val  groups
+    val  benchmark_runs
+    path machine_files
     path benchmark_aws_cur_report
     val  remove_failed_tasks
 
@@ -26,13 +27,22 @@ process BENCHMARK_REPORT {
     export QUARTO_CACHE=/tmp/quarto/cache
     export XDG_CACHE_HOME=/tmp/quarto
 
+    # Copy the baseline report project from the container and overlay repo-managed fixes.
+    cp -R /project report_project
+    cp -R ${projectDir}/modules/local/benchmark_report/overrides/. report_project/
+
     # Create the benchmark samplesheet csv
-    echo "group,file_path" > ${benchmark_samplesheet}
-    ${groups.withIndex().collect { group, idx ->
-        "echo \"${group},\$TASK_DIR/${run_dumps[idx]}\" >> ${benchmark_samplesheet}"
+    echo "group,file_path,machines_path" > ${benchmark_samplesheet}
+    ${benchmark_runs.collect { run ->
+        def group = run.group ?: ''
+        def fileName = run.file_name
+        def machinesName = run.machines_name ?: ''
+        def stagedFilePath = fileName ? "\$TASK_DIR/${fileName}" : ''
+        def stagedMachinesPath = machinesName ? "\$TASK_DIR/${machinesName}" : ''
+        "echo \"${group},${stagedFilePath},${stagedMachinesPath}\" >> ${benchmark_samplesheet}"
     }.join('\n')}
 
-    cd /project
+    cd report_project
     quarto render main_benchmark_report.qmd \\
         -P log_csv:"\$TASK_DIR/"${benchmark_samplesheet} \\
         $aws_cost_param \\
@@ -40,7 +50,7 @@ process BENCHMARK_REPORT {
         --output-dir .\\
         --output benchmark_report.html
 
-    cp /project/benchmark_report.html "\$TASK_DIR/"
+    cp benchmark_report.html "\$TASK_DIR/"
     cd "\$TASK_DIR/"
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/benchmark_report/main.nf
+++ b/modules/local/benchmark_report/main.nf
@@ -14,18 +14,14 @@ process BENCHMARK_REPORT {
     path "versions.yml"          , emit: versions
 
     script:
-    def aws_cost_param = benchmark_aws_cur_report ? "--profile cost -P aws_cost:\$TASK_DIR/${benchmark_aws_cur_report}" : ""
+    def aws_cost_param = benchmark_aws_cur_report ? "--aws_cost \$TASK_DIR/${benchmark_aws_cur_report}" : ""
     def benchmark_samplesheet = "benchmark_samplesheet.csv"
-    def failed_tasks = remove_failed_tasks ? "-P remove_failed_tasks:True" : ""
+    def failed_tasks = remove_failed_tasks ? "--remove_failed_tasks" : ""
 
     """
     # Set up R environment from renv
     export R_LIBS_USER=/project/renv/library/linux-ubuntu-noble/R-4.4/x86_64-pc-linux-gnu
     TASK_DIR="\$PWD"
-
-    # Setup cache directories
-    export QUARTO_CACHE=/tmp/quarto/cache
-    export XDG_CACHE_HOME=/tmp/quarto
 
     # Copy the baseline report project from the container and overlay repo-managed fixes.
     cp -R /project report_project
@@ -43,12 +39,11 @@ process BENCHMARK_REPORT {
     }.join('\n')}
 
     cd report_project
-    quarto render main_benchmark_report.qmd \\
-        -P log_csv:"\$TASK_DIR/"${benchmark_samplesheet} \\
+    Rscript render_benchmark_report.R \\
+        --log_csv "\$TASK_DIR/"${benchmark_samplesheet} \\
+        --output benchmark_report.html \\
         $aws_cost_param \\
-        $failed_tasks \\
-        --output-dir .\\
-        --output benchmark_report.html
+        $failed_tasks
 
     cp benchmark_report.html "\$TASK_DIR/"
     cd "\$TASK_DIR/"

--- a/modules/local/benchmark_report/overrides/benchmark_functions.R
+++ b/modules/local/benchmark_report/overrides/benchmark_functions.R
@@ -1,0 +1,487 @@
+library(RColorBrewer)
+library(pals)
+
+## Color options for grouping
+groups_color_palette <- c("#0DC09D","#3D95FD","#F18046","#160F26","#FA6863","#EAEBEB")
+instance_palette <- alphabet2()
+# Add another color palette to instance_palette to make it be able to be used with up to 50 colors
+instance_palette <- c(instance_palette, alphabet())
+
+# based on palette by Paul Tol: https://personal.sron.nl/~pault/
+#groups_color_palette <- c("#4477AA", "#EE6677", "#228833", "#CCBB44","#66CCEE", "#AA3377", "#BBBBBB") 
+
+# Define a function to convert hex colors to RGBA with alpha
+hex_to_rgba <- function(hex, alpha) {
+  rgb <- col2rgb(hex)
+  rgba <- sprintf("rgba(%d,%d,%d,%.2f)", rgb[1], rgb[2], rgb[3], alpha)
+  return(rgba)
+}
+
+## Include functions
+create_link <- function(value, url_table) {
+  if(length(value) > 1){
+    id_unlist <- unlist(value)
+    id_url_list <- list()
+    for(id in id_unlist){
+      url <- url_table$runUrl[url_table$run_id == id]
+      id_url_list <- c(id_url_list,sprintf('<a href="%s" target="_blank">%s</a>', url, id))
+    }
+    # connect strings in id_url_list
+    return(paste(id_url_list, collapse = " \n"))
+  }else{
+    if (is.na(value) || !value %in% url_table$run_id) {
+      return(value)  # Return the value as is if no URL mapping is found
+    }
+    url <- url_table$runUrl[url_table$run_id == value]
+    if (length(url) == 0 || is.na(url)) {
+      return(value)  # Return the value as is if URL is missing or NA
+    }
+    if (length(url) == 0 || is.na(url)) {
+      return(value)  # Return the value as is if URL is missing or NA
+    }
+    sprintf('<a href="%s" target="_blank">%s</a>', url, value)
+  }
+}
+
+# Function to extract json fields safely
+safe_extract <- function(json, element, default = NA) {
+  if (!is.null(json[[element]])) {
+    return(json[[element]])
+  } else {
+    return(default)
+  }
+}
+
+set_ggplotly_font <- function(plotly_obj) {
+  plotly_obj %>%
+    layout(
+      legend = list(
+        font = list(size = 17),
+        title = list(font = list(size = 17))
+      )
+    )
+}
+
+# Function to add padding to single-digit numbers
+pad_labels <- function(x) {
+  ifelse(nchar(x) == 1 | nchar(x) == 2, paste0(" ", x, " "), x)
+}
+
+# Function to convert hours in double format to HH:MM:SS
+milliseconds_to_hms <- function(time_ms) {
+  if (is.null(time_ms) || length(time_ms) == 0 || is.na(time_ms)) {
+    return(NA_character_)
+  }
+  
+  time_sec <- time_ms / 1000
+  hours <- floor(time_sec / 3600)
+  minutes <- floor((time_sec %% 3600) / 60)
+  seconds <- round(time_sec %% 60)
+  
+  # Adjust minutes and hours if seconds round to 60
+  if (seconds == 60) {
+    seconds <- 0
+    minutes <- minutes + 1
+    if (minutes == 60) {
+      minutes <- 0
+      hours <- hours + 1
+    }
+  }
+  
+  sprintf("%02d:%02d:%02d", hours, minutes, seconds)
+}
+
+
+## Parse tw run dumps tar.gz files
+process_platform_logs <- function(log_files){
+  
+  all_log_paths <- c()
+  base_paths <- c()
+  
+  ## Process logs for each run specified in log_files
+  for (i in 1:nrow(log_files)){
+    file_path <- log_files[i, file_path]
+    file_basepath <- gsub(".tar.gz", "", file_path)
+    base_paths <- c(base_paths, file_basepath)
+    if(file.exists(file_path)){
+      if(!dir.exists(file_basepath)){
+        if(endsWith(file_path, ".tar.gz")){
+          untar(file_path, exdir = file_basepath)
+        }
+      }
+      
+      # Check for double-nested folder structure
+      nested_folder <- list.files(file_basepath, full.names = TRUE)
+      if(length(nested_folder) == 1 && dir.exists(nested_folder)){
+        file_basepath <- nested_folder
+      }
+      
+      log_file_names <- list.files(file_basepath)
+      ## Some manual checks to make sure log files are inside file_basepath
+      if(length(log_file_names) == 0){
+        stop(paste("Error: The file:", file_path, "you were trying to access does not contain any files!"))
+      } else {
+        # Check that all json files are inside log_file_names
+        required_files <- c("workflow.json", "service-info.json", "workflow-load.json", "workflow-launch.json", "workflow-tasks.json", "workflow-metadata.json")
+        if(!all(required_files %in% log_file_names)){
+          missing_files <- setdiff(required_files, log_file_names)
+          stop(paste("Error: The file:", file_path, "you were trying to access does not contain all the necessary json log files:\n",
+                     paste("- ", missing_files, collapse = "\n")))
+        }
+      }
+      unzipped_files <- list.files(file_basepath, full.names = TRUE)
+      all_log_paths <- c(all_log_paths, unzipped_files)
+    } else {
+      stop(paste("Error: The file:", file_path, "you were trying to access does not exist!"))
+    }
+  }
+  
+  ## Add baspaths as column to log_files for easy group lookup
+  log_files$base_path <- base_paths
+  log_files$workflow_logs <-  all_log_paths[grepl("workflow.json", all_log_paths)]
+  log_files$service_logs <- all_log_paths[grepl("service-info.json", all_log_paths)]
+  log_files$load_logs <-  all_log_paths[grepl("workflow-load.json", all_log_paths)]
+  log_files$launch_logs <- all_log_paths[grepl("workflow-launch.json", all_log_paths)]
+  # Check if a file named workflow-tasks.workdir_size.json is available in all_log_paths and add it to log_files if it exists
+  if(length(unique(grepl("workflow-tasks.workdir_size.json", all_log_paths))) > 1) {
+    log_files$task_logs <- all_log_paths[grepl("workflow-tasks.workdir_size.json", all_log_paths)]
+  }else{
+    log_files$task_logs <- all_log_paths[grepl("workflow-tasks.json", all_log_paths)]
+  }
+  meta_logs <- all_log_paths[grepl("workflow-metadata.json", all_log_paths)]
+  # For all file paths in all_log_paths, check whether their base path exists in log_files$base_path. If it does, add that file path as a column to log_files, otherwise add an empty string
+  log_files$meta_logs <- sapply(log_files$base_path, function(base_path){
+    # Construct the expected file path from base_path
+    expected_path <- paste0(base_path, "/workflow-metadata.json")
+    # Check if the expected path exists in meta_logs
+    if (expected_path %in% meta_logs) {
+      return(expected_path)
+    } else {
+      return("")
+    }
+  })
+  
+  ################
+  #### Workflow logs
+  ## Read in the json files for each dir in unzipped files. Add the name of the dir as a column
+  tw_run_dumps_workflow <- apply(log_files,1, function(row){
+    workflow_log <- row["workflow_logs"]
+    json_data <- jsonlite::fromJSON(workflow_log)
+    start_time <- ymd_hms(json_data$start)
+    complete_time <- ymd_hms(json_data$complete)
+    
+    wall_time <- milliseconds_to_hms(json_data$duration)
+    
+    # Check if the run name of json_data contains nf-stresstest
+    if(grepl("nf-stresstest", json_data$runName)){
+      runName <- as.character(str_extract(json_data$runName, "[A-Z]{3}\\d+"))
+    }else{
+      runName <- json_data$runName
+    }
+ 
+    # Extract the summary
+    json_data <- data.frame(
+      RunID = json_data$id,
+      Group = row["group"],
+      run_name = runName,
+      Repository = json_data$repository,
+      Version =  safe_extract(json_data, "revision"),
+      Wall_time = wall_time,
+      duration = json_data$duration,
+      Nextflow_version = json_data$nextflow$version,
+      #pipeline = json_data$manifest$name,
+      succeedCount = json_data$stats$succeedCount,
+      failedCount = json_data$stats$failedCount,
+      username = json_data$userName,
+      stringsAsFactors = FALSE
+    )
+  })
+  
+  ## Combine the data.tables into a single data.table
+  tw_run_dumps_workflow_full <- rbindlist(tw_run_dumps_workflow, fill = TRUE)
+  tw_run_dumps_workflow_full <- tw_run_dumps_workflow_full %>% unique()
+  
+  ## Add RunID from workflow.json to log_files for easy access for other logs
+  log_files$RunID <- tw_run_dumps_workflow_full$RunID
+  
+  ################
+  #### SERVICE logs
+  tw_run_dumps_service <- apply(log_files,1, function(row){
+    service_log <- row["service_logs"]
+    json_data <- jsonlite::fromJSON(service_log)
+    
+    #json_data$RunID <- sapply(strsplit(service_log, "/"), function(json_data) json_data[length(json_data) - 1])
+    json_data <- data.frame(
+      #sample_name = json_data$runName,
+      RunID = row["RunID"],
+      platform_version = json_data$version,
+      seqeraCloud = json_data$seqeraCloud,
+      stringsAsFactors = FALSE
+    )
+  })
+  
+  tw_run_dumps_service_full <- rbindlist(tw_run_dumps_service, fill = TRUE)
+  tw_run_dumps_service_full <- tw_run_dumps_service_full %>% unique()
+  
+  ################
+  #### LOAD logs
+  tw_run_dumps_load <- apply(log_files,1, function(row){
+    load_log <- row["load_logs"]
+    json_data <- jsonlite::fromJSON(load_log)
+    json_data <- as.data.frame(json_data)
+    json_data$RunID <- row["RunID"]
+    # Identify columns with different values
+    diff_cols <- sapply(json_data, function(col) length(unique(col)) > 1)
+    
+    # For columns with different values, join them into a single string
+    for (col in names(json_data)[diff_cols]) {
+      json_data[[col]] <- paste(unique(json_data[[col]]), collapse = ",")
+    }
+    
+    # Convert to a single row data frame
+    json_data <- json_data[1, , drop = FALSE]
+    
+    # Ensure RunID is included
+    json_data$RunID <- row["RunID"]
+    json_data
+
+  })
+  tw_run_dumps_load_full <- rbindlist(tw_run_dumps_load, fill = TRUE)
+  tw_run_dumps_load_full <- tw_run_dumps_load_full %>% unique()
+  
+  ################
+  #### LAUNCH logs
+  tw_run_dumps_launch <- apply(log_files,1, function(row){
+    launch_log <- row["launch_logs"]
+    json_data <- jsonlite::fromJSON(launch_log)
+    
+    # Define expected fields
+    expected_fields <- c("workDir", "preRunScript", "resume", "pullLatest", "stubRun", "configProfiles", "dateCreated", "lastUpdated", "computeEnv")
+    
+    # Check for missing fields
+    missing_fields <- setdiff(expected_fields, names(json_data))
+    if (length(missing_fields) > 0) {
+      warning(paste("Missing fields in launch log for RunID", row["RunID"], ":", paste(missing_fields, collapse = ", ")))
+    }
+    
+    # Use safe_extract for all fields
+    json_data <- data.frame(
+      RunID = row["RunID"],
+      work_dir = safe_extract(json_data, "workDir"),
+      pre_run_script = paste(safe_extract(json_data, "preRunScript", ""), collapse = ", "),
+      resume = safe_extract(json_data, "resume"),
+      pull_latest = safe_extract(json_data, "pullLatest"),
+      stub_run = safe_extract(json_data, "stubRun"),
+      config_profiles = paste(safe_extract(json_data, "configProfiles", ""), collapse = ", "),
+      date_created = safe_extract(json_data, "dateCreated"),
+      last_updated = safe_extract(json_data, "lastUpdated"),
+      executor = safe_extract(json_data$computeEnv, "platform"),
+      provisioning = ifelse(is.null(json_data$computeEnv$platform), NA,
+                            switch(json_data$computeEnv$platform,
+                                   "slurm-platform" = "HPC",
+                                   "google-batch" = "google-batch",
+                                   "azure-batch" = "azure-batch",
+                                   safe_extract(json_data$computeEnv$config$forge, "type"))),
+      max_cpu = ifelse(is.null(json_data$computeEnv$platform), NA,
+                       switch(json_data$computeEnv$platform,
+                              "slurm-platform" = "NA",
+                              "google-batch" = "NA",
+                              "azure-batch" = "NA",
+                              safe_extract(json_data$computeEnv$config$forge, "maxCpus"))),
+      gpu_enabled = ifelse(is.null(json_data$computeEnv$platform), NA,
+                           switch(json_data$computeEnv$platform,
+                                  "slurm-platform" = FALSE,
+                                  "google-batch" = FALSE,
+                                  "azure-batch" = FALSE,
+                                  safe_extract(json_data$computeEnv$config$forge, "gpuEnabled"))),
+      ebs_autoscale = ifelse(is.null(json_data$computeEnv$platform), NA,
+                             switch(json_data$computeEnv$platform,
+                                    "slurm-platform" = FALSE,
+                                    "google-batch" = FALSE,
+                                    "azure-batch" = FALSE,
+                                    safe_extract(json_data$computeEnv$config$forge, "ebsAutoScale"))),
+      region = ifelse(is.null(json_data$computeEnv$platform), NA,
+                      switch(json_data$computeEnv$platform,
+                             "slurm-platform" = "NA",
+                             "google-batch" = safe_extract(json_data$computeEnv$config, "location"),
+                             "azure-batch" = safe_extract(json_data$computeEnv$config, "region"),
+                             safe_extract(json_data$computeEnv$config, "region"))),
+      waveEnabled = safe_extract(json_data$computeEnv$config, "waveEnabled"),
+      fusion_enabled = safe_extract(json_data$computeEnv$config, "fusion2Enabled"),
+      nvnmeStorageEnabled = safe_extract(json_data$computeEnv$config, "nvnmeStorageEnabled"),
+      instanceTypes = ifelse(is.null(json_data$computeEnv$platform), NA,
+                             switch(json_data$computeEnv$platform,
+                                    "slurm-platform" = "HPC",
+                                    "google-batch" = "",
+                                    "azure-batch" = "",
+                                    paste(safe_extract(json_data$computeEnv$config$forge, "instanceTypes", ""), collapse = ", ")))
+    )
+  })
+  
+  # Check if any of the data frames in the list are empty
+  empty_dfs <- sapply(tw_run_dumps_launch, function(df) nrow(df) == 0)
+  if (any(empty_dfs)) {
+    warning(paste("Empty data frames found for RunIDs:", 
+                  paste(log_files$RunID[empty_dfs], collapse = ", ")))
+  }
+  
+  tw_run_dumps_launch_full <- rbindlist(tw_run_dumps_launch, fill = TRUE)
+  tw_run_dumps_launch_full <- tw_run_dumps_launch_full %>% unique()
+  
+  ################
+  #### TASK logs
+  ## Read in the json files for each dir in unzipped files. Add the name of the dir as a column
+  tw_run_dumps_tasks <- apply(log_files,1, function(row){
+    task_log <- row["task_logs"]
+    json_data <- jsonlite::fromJSON(task_log)
+    json_data$RunID <- row["RunID"]
+    json_data$Group = row["group"]
+    json_data <- as.data.table(json_data)
+  })
+  tw_run_dumps_tasks_full <- rbindlist(tw_run_dumps_tasks, fill = TRUE)
+  
+  ################
+  #### METADATA logs
+  # Read in the json files for each dir in unzipped files. Add the name of the dir as a column
+  tw_run_dumps_meta <- apply(log_files,1, function(row){
+    meta_log <- row["meta_logs"]
+    if(meta_log != ""){
+      json_data <- jsonlite::fromJSON(meta_log)
+      # Drop element "labels" from json_data as t his causes duplication of rows
+      json_data$labels <- paste(json_data$labels$name, collapse = ",")
+      json_data$RunID <- row["RunID"]
+      json_data <- as.data.table(json_data)
+    }
+  })
+  
+  tw_run_dumps_meta_full <- rbindlist(tw_run_dumps_meta, fill = TRUE)
+
+  return(list("workflow" = tw_run_dumps_workflow_full,
+              "service" = tw_run_dumps_service_full,
+              "load" = tw_run_dumps_load_full,
+              "launch" = tw_run_dumps_launch_full,
+              "workflow_tasks" = tw_run_dumps_tasks_full,
+              "metadata" = tw_run_dumps_meta_full)
+  )
+}
+
+## Theming function from Adam
+seqera_light_theme <- function() {
+  library(ggplot2)
+  library(showtext)
+  library(viridis)
+  
+  theme(
+    plot.background = element_rect(fill = "#FFFFFF", color = NA), # Plot background (white)
+    panel.background = element_rect(fill = "#FFFFFF", color = NA), # Panel background (white)
+    panel.grid.major = element_line(color = "#d3d3d3", linetype = "dashed"), # Dashed major grid lines
+    panel.grid.minor = element_blank(), # Remove minor grid lines
+    panel.border = element_blank(), # Remove panel border
+    
+    # Text
+    text = element_text(color = "#160F26"), # Default text color
+    plot.title = element_text(size = 18, face = "bold", color = "#160F26", hjust = 0.5), # Title
+    plot.subtitle = element_text(size = 14, color = "#7B7B7B", hjust = 0.5), # Subtitle
+    axis.title = element_text(size = 12, face = "bold", color = "#160F26"), # Axis titles
+    axis.text = element_text(size = 10, color = "#160F26"), # Axis text
+    legend.title = element_text(size = 12, face = "bold", color = "#160F26"), # Legend title
+    legend.text = element_text(size = 10, color = "#160F26"), # Legend text
+    
+    # Axis lines and ticks
+    axis.line = element_line(color = "#160F26"), # Axis lines
+    axis.ticks = element_line(color = "#160F26"), # Axis ticks
+    
+    # Legend
+    legend.background = element_blank(), # Remove legend background
+    legend.key = element_rect(fill = "#FFFFFF", color = NA), # Legend key background
+    
+    # Facet labels
+    strip.background = element_rect(fill = "#160F26", color = NA), # Facet background color
+    strip.text = element_text(size = 12, color = "#FFFFFF") # Facet label text color
+  )
+}
+
+seqera_colour <- function(...) {
+  seqera_colours <- c(
+    `dark`       = "#160F26",
+    `dark_gray`  = "#7B7B7B",
+    `light_gray` = "#EAEBEB",
+    `red`        = "#FA6863",
+    `green`      = "#0DC09D",
+    `blue`       = "#3D95FD",
+    `orange`     = "#F18046",
+    `fusion`     = "#FA6863",
+    `nextflow`   = "#0DC09D",
+    `wave`       = "#3D95FD",
+    `multiqc`    = "#F18046"
+  )
+  cols <- c(...)
+  if (is.null(cols))
+    return (seqera_colours)
+  seqera_colours[cols]
+}
+
+seqera_palette <- function(palette = "product", ...) {
+  seqera_palettes <- list(
+    `complete` = seqera_colour(),
+    `background` = seqera_colour("dark", "dark_gray", "light_gray"),
+    `product` = seqera_colour("nextflow", "fusion", "wave", "multiqc"),
+    `fusion` = seqera_colour("fusion", "multiqc"),
+    `nextflow` = seqera_colour("nextflow", "wave"),
+    `wave` = seqera_colour("wave", "nextflow"),
+    `multiqc` = seqera_colour("multiqc", "fusion")
+  )
+  return(seqera_palettes[[palette]])
+}
+
+palette_gen <- function(palette = "product", reverse = FALSE, ...) {
+  pal <- seqera_palette(palette)
+  pal <- if (reverse) rev(pal) else pal
+  colorRampPalette(pal, ...)
+}
+
+scale_fill_seqera <- function(palette = "product", reverse = FALSE, ...) {
+  ggplot2::discrete_scale(
+    "fill", 'seqera',
+    palette_gen(palette = palette, reverse = reverse),
+    ...
+  )
+}
+
+scale_discrete_seqera <- function(palette = "product", reverse = FALSE, ...) {
+  ggplot2::discrete_scale(
+    "colour", 'seqera',
+    palette_gen(palette = palette, reverse = reverse),
+    ...
+  )
+}
+
+scale_continuous_seqera <- function(palette = "product", reverse = FALSE, ...) {
+  pal <- palette_gen_c(palette = palette, reverse = reverse)
+  scale_color_gradientn(colors = pal(256), ...)
+}
+
+## Function to create a badge in reactable
+badge <- function(text, color = "#e8a87c") {
+  library(htmltools)
+  div(style = list(
+    display = "inline-block",
+    padding = "4px 12px",
+    margin = "2px",
+    color = "white",
+    backgroundColor = color,
+    borderRadius = "12px",
+    fontSize = "14px",
+    fontWeight = "bold",
+    textAlign = "center",
+    verticalAlign = "middle"
+  ), text)
+}
+
+# Custom scale function to add buffer
+expand_x_limits <- function(x) {
+  rng <- range(x, na.rm = TRUE)
+  buffer <- (rng[2] - rng[1]) * 0.2  # 20% buffer
+  c(rng[1], rng[2] + buffer)
+}
+

--- a/modules/local/benchmark_report/overrides/benchmark_report_template.html
+++ b/modules/local/benchmark_report/overrides/benchmark_report_template.html
@@ -150,7 +150,7 @@
 
     <h2 id="methodology"><svg class="h-icon sm"><use href="#ic-table"/></svg> Methodology &mdash; what each utilization metric means</h2>
     <p class="section-desc">
-      The report exposes <strong>four different utilization metrics</strong>. They sound similar
+      The report exposes <strong>three utilization metric families</strong>. They sound similar
       but measure very different things, and in practice they disagree by 2&ndash;5&times;.
       Read this before comparing rows in the run-metrics table below.
     </p>
@@ -218,6 +218,14 @@
       <em>Real VM efficiency</em> is the end-to-end ground truth: what fraction of the VM-hours
       you paid for were actually spent doing work. Trace efficiency &times; Sched allocation
       &asymp; Real VM efficiency (modulo time-weighting).
+    </p>
+    <p class="section-desc" style="margin-top:8px">
+      <strong>CPU time columns in the run table:</strong>
+      <em>Total Trace CPU Time (Task)</em> is &Sigma;<sub>tasks</sub>(cpus<sub>req</sub> &middot; realtime), so it reflects
+      what tasks asked for, not what they actually used.
+      <em>Total VM CPU Time</em> is &Sigma;<sub>VMs</sub>(vCPU &middot; lifetime), the capacity you paid for.
+      Those two can be close while Trace CPU efficiency stays low, because Trace CPU efficiency compares
+      <em>used</em> CPU against <em>requested</em> CPU, not requested CPU against VM capacity.
     </p>
     <p class="section-desc">
       VM-level metrics require a <code>machines.jsonl</code> in the JSONL bundle
@@ -896,7 +904,8 @@ document.getElementById('group-list').innerHTML = groups.map(g =>
   const costs = DATA.run_costs || [];
   if (!metrics.length) return;
   const table = document.getElementById('run-metrics-table');
-  const cols = ['Pipeline name','Group','Run ID','Duration','CPU time (hours)',
+  const cols = ['Pipeline name','Group','Run ID','Duration','Total Trace CPU Time (Task)',
+                'Total VM CPU Time',
                 'Compute cost ($)','Read (GB)','Write (GB)',
                 'Trace CPU eff (task) %','Trace Mem eff (task) %',
                 'Sched alloc CPU (VM) %','Sched alloc Mem (VM) %',
@@ -916,6 +925,7 @@ document.getElementById('group-list').innerHTML = groups.map(g =>
     html += '<td>' + r.run_id + '</td>';
     html += '<td>' + fmtDuration(r.duration) + '</td>';
     html += '<td>' + fmtHours(r.cpuTime) + '</td>';
+    html += '<td>' + fmtHours(r.vmCpuH) + '</td>';
     html += '<td>' + fmtCost(c.cost) + '</td>';
     html += '<td>' + fmtGB(r.readBytes) + '</td>';
     html += '<td>' + fmtGB(r.writeBytes) + '</td>';
@@ -945,17 +955,13 @@ function hbarChart(elId, title, labels, values, opts) {
     itemStyle: opts.color ? { color: opts.color, borderRadius: [0, 2, 2, 0] }
                           : { borderRadius: [0, 2, 2, 0] },
     emphasis: { focus: 'series' } }];
-  if (seriesArray.length > 1 && seriesArray.length <= 3) {
-    seriesArray.forEach(s => {
-      s.label = { show: true, position: 'right', formatter: '{a}' };
-    });
-  }
   echarts.init(el, 'seqera').setOption({
     title: { text: title, subtext: opts.subtitle || '' },
+    legend: { show: seriesArray.length > 1, bottom: 0 },
     tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' },
       formatter: opts.formatter || (p => p[0].name + ': ' + (opts.prefix||'') +
         p[0].value.toLocaleString(undefined, {maximumFractionDigits:2}) + (opts.suffix||'')) },
-    grid: { top: opts.subtitle ? 60 : 40, bottom: 30, containLabel: true },
+    grid: { top: opts.subtitle ? 60 : 40, bottom: seriesArray.length > 1 ? 55 : 30, containLabel: true },
     xAxis: { type: 'value', name: opts.xName || '', nameLocation: 'center',
       nameGap: 25, axisLabel: { hideOverlap: true } },
     yAxis: { type: 'category', data: labels.slice().reverse() },
@@ -996,9 +1002,36 @@ function hbarStacked(elId, title, labels, seriesDefs, opts) {
   hbarChart('chart-wall-time', 'Wall time', labels, wallValues,
     { xName: 'Hours', suffix: ' h', subtitle: takeaway(labels, wallValues, { lowerBetter: true, adjective: 'faster', suffix: ' h' }) });
 
-  const cpuValues = metrics.map(r => +(r.cpuTime || 0));
-  hbarChart('chart-cpu-time', 'CPU time', labels, cpuValues,
-    { xName: 'CPU Hours', suffix: ' h', subtitle: takeaway(labels, cpuValues, { lowerBetter: true, adjective: 'lower', suffix: ' h' }) });
+  const traceCpuValues = metrics.map(r => +(r.cpuTime || 0));
+  const vmCpuValues = metrics.map(r => +(r.vmCpuH || 0));
+  hbarChart('chart-cpu-time', 'CPU time totals', labels, traceCpuValues,
+    {
+      xName: 'CPU Hours',
+      suffix: ' h',
+      subtitle: 'Task trace CPU-hours vs total VM CPU-hours provisioned',
+      series: [
+        {
+          name: 'Total Trace CPU Time (Task)',
+          type: 'bar',
+          data: traceCpuValues.slice().reverse(),
+          itemStyle: { color: '#065647', borderRadius: [0, 2, 2, 0] },
+          emphasis: { focus: 'series' }
+        },
+        {
+          name: 'Total VM CPU Time',
+          type: 'bar',
+          data: vmCpuValues.slice().reverse(),
+          itemStyle: { color: '#a9b6bf', borderRadius: [0, 2, 2, 0] },
+          emphasis: { focus: 'series' }
+        }
+      ],
+      formatter: function(points) {
+        const rows = points.map(p =>
+          p.marker + ' ' + p.seriesName + ': ' + Number(p.value).toLocaleString(undefined, {maximumFractionDigits: 2}) + ' h'
+        );
+        return points[0].name + '<br>' + rows.join('<br>');
+      }
+    });
 
   const costValues = metrics.map(r => { const c = costs.find(x => x.run_id === r.run_id); return c ? +c.cost : 0; });
   hbarChart('chart-est-cost', 'Compute cost', labels, costValues,

--- a/modules/local/benchmark_report/overrides/benchmark_report_template.html
+++ b/modules/local/benchmark_report/overrides/benchmark_report_template.html
@@ -1,0 +1,1487 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Pipeline benchmarking report</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: 'Inter', Helvetica, sans-serif;
+         background: #ffffff; color: #201637; line-height: 1.6; font-size: 14px; }
+  .container { max-width: 1200px; margin: 0 auto; padding: 0 15px; }
+
+  .navbar { background: #ffffff; border-bottom: 1px solid #CFD0D1; padding: 12px 0; margin-bottom: 30px; }
+  .navbar .container { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+  .navbar-brand { display: flex; align-items: center; gap: 12px; text-decoration: none; color: #000000; }
+  .navbar-brand svg { height: 28px; display: block; }
+  .navbar-right { color: #000000; font-size: 13px; font-weight: 500; }
+
+  .section { margin-bottom: 40px; }
+  .section h1 { font-size: 26px; font-weight: 600; color: #201637; margin-bottom: 5px;
+                 padding-bottom: 8px; border-bottom: 1px solid #CFD0D1; }
+  .section h2 { font-size: 20px; font-weight: 500; color: #201637; margin: 25px 0 8px;
+                 padding-bottom: 5px; border-bottom: 1px solid #CFD0D1; }
+  .section h3 { font-size: 17px; font-weight: 500; color: #201637; margin: 20px 0 8px; }
+  .section-desc { color: #201637; font-size: 13px; margin-bottom: 15px; line-height: 1.5; }
+  .section-desc strong { color: #201637; font-weight: 600; }
+
+  .gs-table { width: 100%; border-collapse: collapse; font-size: 12px; margin-bottom: 20px; }
+  .gs-table th { background: #F7F7F7; padding: 6px 10px; text-align: center; font-weight: 600;
+                  border-bottom: 2px solid #CFD0D1; white-space: nowrap; }
+  .gs-table th:first-child { text-align: left; }
+  .gs-table td { padding: 5px 10px; border-bottom: 1px solid #CFD0D1; text-align: center; white-space: nowrap; }
+  .gs-table td:first-child { text-align: left; font-weight: 600; }
+  .gs-table tr:hover td { background: #E2F7F3; }
+  .gs-table a { color: #087F68; text-decoration: none; }
+
+  .chart { width: 100%; height: 400px; margin-bottom: 24px; }
+  .chart-row { display: grid; grid-template-columns: 1fr 1fr; gap: 32px; margin-bottom: 24px; }
+
+  .info-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .info-table th { background: #F7F7F7; padding: 6px 10px; text-align: left; font-weight: 600;
+                    border-bottom: 2px solid #CFD0D1; }
+  .info-table td { padding: 5px 10px; border-bottom: 1px solid #CFD0D1; }
+  .info-table tr:hover td { background: #E2F7F3; }
+
+  .callout { border: 1px solid #CFD0D1; border-radius: 4px; margin-bottom: 15px; }
+  .callout-header { background: #F7F7F7; padding: 8px 12px; cursor: pointer; font-size: 13px;
+                     font-weight: 600; color: #201637; border-bottom: 1px solid #CFD0D1; }
+  .callout-header:hover { background: #E2F7F3; }
+  .callout-body { padding: 12px; display: none; }
+  .callout-body.show { display: block; }
+
+  .dl-row { display: flex; gap: 20px; font-size: 13px; margin-bottom: 8px; flex-wrap: wrap; }
+  .dl-row dt { font-weight: 600; color: #201637; }
+  .dl-row dd { color: #201637; margin-right: 15px; }
+
+  footer { border-top: 1px solid #CFD0D1; padding: 15px 0; margin-top: 40px;
+           font-size: 12px; color: #CFD0D1; text-align: center; }
+  footer a { color: #087F68; text-decoration: none; }
+
+  .side-nav { position: fixed; top: 53px; left: 0; width: 228px; padding: 12px 8px;
+              background: #ffffff; border-right: 1px solid #CFD0D1; height: calc(100vh - 53px);
+              overflow-y: auto; font-size: 12px; z-index: 100; }
+  .nav-icon { width: 14px; height: 14px; vertical-align: -2px; margin-right: 6px; flex-shrink: 0; color: #000000; }
+  .h-icon { width: 24px; height: 24px; vertical-align: -4px; margin-right: 6px; color: #087F68; }
+  .h-icon.sm { width: 20px; height: 20px; vertical-align: -3px; margin-right: 5px; }
+  .side-nav a { display: flex; align-items: center; padding: 8px 10px; margin-bottom: 2px; color: #000000; text-decoration: none;
+                border-radius: 6px; transition: background 0.15s ease; }
+  .side-nav a:hover { background: #F7F7F7; color: #000000; }
+  .side-nav a.active { background: #E2F7F3; color: #000000; font-weight: 600; }
+  .side-nav a.l2 { padding-left: 18px; color: #000000; font-size: 12px; }
+  .side-nav a.l3 { padding-left: 28px; color: #000000; font-size: 12px; }
+  .main-content { margin-left: 228px; }
+
+  .csv-btn { float: right; font-size: 13px; color: #087F68; cursor: pointer; border: 1px solid #CFD0D1;
+             background: #ffffff; padding: 2px 10px; border-radius: 3px; text-decoration: none; }
+  .csv-btn:hover { background: #F7F7F7; }
+
+  @media (max-width: 900px) {
+    .side-nav { display: none; }
+    .main-content { margin-left: 0; }
+    .chart-row { grid-template-columns: 1fr; }
+  }
+
+  .text-muted { color: #CFD0D1; }
+  .group-colors span { display: inline-block; width: 12px; height: 12px; border-radius: 2px;
+                        margin-right: 4px; vertical-align: middle; }
+</style>
+</head>
+<body>
+
+<nav class="navbar">
+  <div class="container">
+    <a class="navbar-brand" href="https://seqera.io">
+      <span style="font-size:20px;font-weight:300">seqera</span>
+    </a>
+    <div class="navbar-right">Pipeline benchmarking report</div>
+  </div>
+</nav>
+
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <symbol id="ic-benchmark" viewBox="0 0 20 20"><rect x="2" y="2" width="7" height="7" rx="1" fill="currentColor" opacity=".85"/><rect x="11" y="2" width="7" height="7" rx="1" fill="currentColor" opacity=".55"/><rect x="2" y="11" width="7" height="7" rx="1" fill="currentColor" opacity=".55"/><rect x="11" y="11" width="7" height="7" rx="1" fill="currentColor" opacity=".85"/></symbol>
+  <symbol id="ic-run" viewBox="0 0 20 20"><path d="M6 3.5v13l10-6.5z" fill="currentColor"/></symbol>
+  <symbol id="ic-table" viewBox="0 0 20 20"><rect x="3" y="4" width="14" height="2" rx="1" fill="currentColor"/><rect x="3" y="9" width="14" height="2" rx="1" fill="currentColor"/><rect x="3" y="14" width="14" height="2" rx="1" fill="currentColor"/></symbol>
+  <symbol id="ic-chart" viewBox="0 0 20 20"><rect x="2" y="10" width="4" height="8" rx="1" fill="currentColor"/><rect x="8" y="5" width="4" height="13" rx="1" fill="currentColor"/><rect x="14" y="2" width="4" height="16" rx="1" fill="currentColor"/></symbol>
+  <symbol id="ic-process" viewBox="0 0 20 20"><circle cx="5" cy="10" r="3" fill="currentColor"/><circle cx="15" cy="5" r="2.5" fill="currentColor" opacity=".7"/><circle cx="15" cy="15" r="2.5" fill="currentColor" opacity=".7"/><line x1="7.5" y1="9" x2="12.5" y2="5.5" stroke="currentColor" stroke-width="1.5"/><line x1="7.5" y1="11" x2="12.5" y2="14.5" stroke="currentColor" stroke-width="1.5"/></symbol>
+  <symbol id="ic-task" viewBox="0 0 20 20"><rect x="2" y="2" width="16" height="16" rx="2" fill="none" stroke="currentColor" stroke-width="1.5"/><path d="M6 10l2.5 2.5L14 7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></symbol>
+  <symbol id="ic-instance" viewBox="0 0 20 20"><rect x="3" y="2" width="14" height="5" rx="1.5" fill="currentColor"/><rect x="3" y="9" width="14" height="5" rx="1.5" fill="currentColor" opacity=".65"/><circle cx="6" cy="4.5" r="1" fill="#fff"/><circle cx="6" cy="11.5" r="1" fill="#fff"/></symbol>
+  <symbol id="ic-scatter" viewBox="0 0 20 20"><circle cx="5" cy="14" r="1.8" fill="currentColor"/><circle cx="9" cy="8" r="1.8" fill="currentColor" opacity=".75"/><circle cx="14" cy="11" r="1.8" fill="currentColor" opacity=".6"/><circle cx="16" cy="5" r="1.8" fill="currentColor" opacity=".45"/></symbol>
+</svg>
+
+<div class="side-nav" id="side-nav">
+  <a href="#benchmark-overview"><svg class="nav-icon"><use href="#ic-benchmark"/></svg> Benchmark overview</a>
+  <a href="#run-overview"><svg class="nav-icon"><use href="#ic-run"/></svg> Run overview</a>
+  <a href="#run-summary" class="l2"><svg class="nav-icon"><use href="#ic-table"/></svg> Run summary</a>
+  <a href="#run-metrics" class="l2"><svg class="nav-icon"><use href="#ic-chart"/></svg> Run metrics</a>
+  <a href="#process-overview"><svg class="nav-icon"><use href="#ic-process"/></svg> Process overview</a>
+  <a href="#task-overview"><svg class="nav-icon"><use href="#ic-task"/></svg> Task overview</a>
+  <a href="#task-instance-usage" class="l2"><svg class="nav-icon"><use href="#ic-instance"/></svg> Instance usage</a>
+  <a href="#task-metrics" class="l2"><svg class="nav-icon"><use href="#ic-scatter"/></svg> Task metrics</a>
+  <a href="#performance-gains"><svg class="nav-icon"><use href="#ic-benchmark"/></svg> Performance gains</a>
+</div>
+
+<div class="main-content">
+<div class="container">
+
+  <p class="" style="margin-bottom: 25px;">
+    Published <strong>__PUBLISHED_AT__</strong>
+  </p>
+
+  <!-- 1. Benchmark overview -->
+  <div class="section" id="benchmark-overview">
+    <h1><svg class="h-icon"><use href="#ic-benchmark"/></svg> Benchmark overview</h1>
+    <div class="dl-row">
+      <dt>Failed task excluded</dt><dd>: __FAILED_TASK_EXCLUDED__</dd>
+    </div>
+    <p class="section-desc">
+      <strong>Summary</strong><br>
+      This report summarizes the run, process, task, and, if applicable, cost metrics
+      for pipeline executions, which have been split into groups:
+      <span id="group-list" class="group-colors"></span>
+    </p>
+    <div style="overflow-x: auto;">
+      <table class="gs-table" id="overview-matrix"></table>
+    </div>
+
+    <h2 id="methodology"><svg class="h-icon sm"><use href="#ic-table"/></svg> Methodology &mdash; what each utilization metric means</h2>
+    <p class="section-desc">
+      The report exposes <strong>four different utilization metrics</strong>. They sound similar
+      but measure very different things, and in practice they disagree by 2&ndash;5&times;.
+      Read this before comparing rows in the run-metrics table below.
+    </p>
+    <table class="info-table" id="methodology-table">
+      <thead>
+        <tr>
+          <th style="width:22%">Metric</th>
+          <th style="width:8%">Level</th>
+          <th style="width:8%">Resource</th>
+          <th>Numerator</th>
+          <th>Denominator</th>
+          <th style="width:26%">What it captures</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td rowspan="2"><strong>Trace efficiency (task)</strong><br><span class="text-muted">cpuEfficiency / memoryEfficiency</span></td>
+          <td rowspan="2">Task</td>
+          <td><strong>CPU</strong></td>
+          <td>&Sigma;<sub>tasks</sub>&nbsp;(pcpu / 100 &middot; realtime)</td>
+          <td>&Sigma;<sub>tasks</sub>&nbsp;(cpus<sub>req</sub> &middot; realtime)</td>
+          <td rowspan="2">How close each task came to using what it asked for. Ignores VM packing and VM idle time.</td>
+        </tr>
+        <tr>
+          <td><strong>Memory</strong></td>
+          <td>&Sigma;<sub>tasks</sub>&nbsp;(peakRss &middot; realtime)</td>
+          <td>&Sigma;<sub>tasks</sub>&nbsp;(memory<sub>req</sub> &middot; realtime)</td>
+        </tr>
+        <tr>
+          <td rowspan="2"><strong>Sched allocation (VM)</strong><br><span class="text-muted">schedAllocCpuEfficiency / schedAllocMemEfficiency</span></td>
+          <td rowspan="2">VM</td>
+          <td><strong>CPU</strong></td>
+          <td>&Sigma;<sub>VMs</sub>&nbsp;(avg_cpu_util &middot; vCPU &middot; lifetime)</td>
+          <td>&Sigma;<sub>VMs</sub>&nbsp;(vCPU &middot; lifetime)</td>
+          <td rowspan="2">
+            How <em>booked</em> each VM was. Per-VM <code>avg_util</code> =
+            &Sigma;(request<sub>task</sub> &middot; task_duration) / (capacity<sub>VM</sub> &middot; vm_lifetime).
+            Drops when a VM sits idle between tasks or when small tasks run on large instances.
+          </td>
+        </tr>
+        <tr>
+          <td><strong>Memory</strong></td>
+          <td>&Sigma;<sub>VMs</sub>&nbsp;(avg_mem_util &middot; memory<sub>VM</sub> &middot; lifetime)</td>
+          <td>&Sigma;<sub>VMs</sub>&nbsp;(memory<sub>VM</sub> &middot; lifetime)</td>
+        </tr>
+        <tr>
+          <td rowspan="2"><strong>Real VM efficiency (VM)</strong><br><span class="text-muted">realVmCpuEfficiency / realVmMemEfficiency</span></td>
+          <td rowspan="2">VM</td>
+          <td><strong>CPU</strong></td>
+          <td>&Sigma;<sub>tasks</sub>&nbsp;(pcpu / 100 &middot; realtime)</td>
+          <td>&Sigma;<sub>VMs</sub>&nbsp;(vCPU &middot; lifetime)</td>
+          <td rowspan="2">Ground truth: what fraction of the VM-hours you paid for was actually spent doing work.</td>
+        </tr>
+        <tr>
+          <td><strong>Memory</strong></td>
+          <td>&Sigma;<sub>tasks</sub>&nbsp;(peakRss &middot; realtime)</td>
+          <td>&Sigma;<sub>VMs</sub>&nbsp;(memory<sub>VM</sub> &middot; lifetime)</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="section-desc" style="margin-top:8px">
+      <strong>How to read them:</strong>
+      <em>Trace efficiency</em> tells you whether users are requesting too much CPU/memory per task.
+      <em>Sched allocation</em> tells you how well the scheduler packs and reuses VMs.
+      <em>Real VM efficiency</em> is the end-to-end ground truth: what fraction of the VM-hours
+      you paid for were actually spent doing work. Trace efficiency &times; Sched allocation
+      &asymp; Real VM efficiency (modulo time-weighting).
+    </p>
+    <p class="section-desc">
+      VM-level metrics require a <code>machines.jsonl</code> in the JSONL bundle
+      (built from a per-run machine CSV &mdash; sched UI <code>/machines</code> export or the
+      <code>instance_summary.csv</code> produced by <code>analyze_idle_periods.py</code>).
+      Runs without machine data show &mdash; for those columns.
+    </p>
+  </div>
+
+  <!-- 2. Run overview -->
+  <div class="section" id="run-overview">
+    <h1><svg class="h-icon"><use href="#ic-run"/></svg> Run overview</h1>
+    <p class="section-desc">
+      <strong>Summary</strong><br>
+      This section provides a high-level overview of the pipeline run metrics.
+    </p>
+
+    <h2 id="run-summary"><svg class="h-icon sm"><use href="#ic-table"/></svg> Run summary</h2>
+    <p class="section-desc">Summary of pipeline execution and infrastructure settings.</p>
+    <div class="callout">
+      <div class="callout-header" onclick="this.nextElementSibling.classList.toggle('show')">
+        &#9654; Click to display table
+      </div>
+      <div class="callout-body show" style="overflow-x:auto">
+        <table class="gs-table" id="run-summary-table"></table>
+      </div>
+    </div>
+
+    <h2 id="run-metrics"><svg class="h-icon sm"><use href="#ic-chart"/></svg> Run metrics</h2>
+    <p class="section-desc">This section provides a visual overview of the pipeline run metrics.</p>
+    <div class="callout">
+      <div class="callout-header" onclick="this.nextElementSibling.classList.toggle('show')">
+        &#9654; Click to display table
+      </div>
+      <div class="callout-body" style="overflow-x:auto">
+        <button class="csv-btn" onclick="downloadCSV('run-metrics-table','run_overview.csv')">Download as CSV</button>
+        <table class="gs-table" id="run-metrics-table"></table>
+      </div>
+    </div>
+
+    <div class="chart-row">
+      <div class="chart" id="chart-wall-time"></div>
+      <div class="chart" id="chart-cpu-time"></div>
+    </div>
+    <div class="chart-row">
+      <div class="chart" id="chart-est-cost"></div>
+      <div class="chart" id="chart-workflow-status"></div>
+    </div>
+    <div class="chart-row">
+      <div class="chart" id="chart-cpu-eff"></div>
+      <div class="chart" id="chart-mem-eff"></div>
+    </div>
+    <div class="chart-row">
+      <div class="chart" id="chart-vm-alloc-cpu"></div>
+      <div class="chart" id="chart-vm-alloc-mem"></div>
+    </div>
+    <div class="chart-row">
+      <div class="chart" id="chart-vm-real-cpu"></div>
+      <div class="chart" id="chart-vm-real-mem"></div>
+    </div>
+    <div class="chart-row">
+      <div class="chart" id="chart-read-io"></div>
+      <div class="chart" id="chart-write-io"></div>
+    </div>
+  </div>
+
+  <!-- 3. Process overview -->
+  <div class="section" id="process-overview">
+    <h1><svg class="h-icon"><use href="#ic-process"/></svg> Process overview</h1>
+    <p class="section-desc">
+      <strong>Summary</strong><br>
+      This section provides a comparison of the process-level metrics for each pipeline
+      across the groups. The plots show the run time distribution per process.
+      Dots represent mean values per process across all tasks.
+      Error bars indicate mean &plusmn; 1 standard deviation.
+      A single point indicates that a single task was executed for the process.
+    </p>
+    <p class="section-desc">
+      <strong>Task duration</strong> = Staging time + real time
+    </p>
+    <div id="process-sections"></div>
+  </div>
+
+  <!-- 4. Task overview -->
+  <div class="section" id="task-overview">
+    <h1><svg class="h-icon"><use href="#ic-task"/></svg> Task overview</h1>
+    <p class="section-desc">
+      <strong>Summary</strong><br>
+      This section provides an overview of task-level metrics for instance usage and runtime metrics.
+    </p>
+
+    <h2 id="task-instance-usage"><svg class="h-icon sm"><use href="#ic-instance"/></svg> Task instance usage</h2>
+    <p class="section-desc">Number of tasks per instance type, grouped by pipeline run group.</p>
+    <div class="chart" id="chart-instance-usage" style="height:500px"></div>
+
+    <h2 id="task-metrics"><svg class="h-icon sm"><use href="#ic-scatter"/></svg> Task metrics</h2>
+    <p class="section-desc">
+      This section provides a comparison between staging and run times for tasks.<br>
+      <strong>Wait time</strong>: time from submission to task start.<br>
+      <strong>Staging time</strong>: time to stage/unstage before and after execution.<br>
+      <strong>Real time</strong>: time to execute the task.
+    </p>
+    <div id="task-sections"></div>
+  </div>
+
+  <!-- 5. Performance gains -->
+  <div class="section" id="performance-gains">
+    <h1><svg class="h-icon"><use href="#ic-benchmark"/></svg> Performance gains</h1>
+    <p class="section-desc">
+      <strong>Summary</strong><br>
+      Decomposes the VM capacity-hours you paid for into <em>used</em> vs <em>wasted</em>,
+      and attributes the waste to the three responsibilities the Seqera scheduler
+      owns: <strong>VM provisioning</strong> (choosing instance types), <strong>packing</strong>
+      (which task on which VM and when), and <strong>task rightsizing</strong>
+      (trimming user-requested CPU/Memory before submitting to ECS, when prediction
+      is enabled).
+    </p>
+    <p class="section-desc">
+      <strong>Four quantities, per run</strong><br>
+      <em>VM capacity</em>: &Sigma;<sub>VMs</sub>&nbsp;(vCPU &middot; lifetime). What you paid for.<br>
+      <em>User requested</em>: &Sigma;<sub>tasks</sub>&nbsp;(cpus<sub>config</sub> &middot; realtime). Nextflow-directive request per task &times; active time.<br>
+      <em>Scheduler booked</em>: schedAllocCpuEfficiency &middot; VM capacity. What actually went to ECS as <code>cpuShares</code> (reflects Predv1 rightsizing when on).<br>
+      <em>Used</em>: &Sigma;<sub>tasks</sub>&nbsp;(pcpu/100 &middot; realtime). Actual work done.<br>
+      Memory analogues use <code>memory<sub>config</sub></code>, <code>schedAllocMemEfficiency</code>, and <code>peakRss</code>.
+    </p>
+    <p class="section-desc">
+      <strong>How the scheduler's three jobs show up</strong><br>
+      &nbsp;&nbsp;&nbsp;&mdash; <em>Rightsizing</em> shrinks <code>scheduler booked</code> below <code>user requested</code>. Visible as the green &ldquo;already saved&rdquo; bar in the savings chart.<br>
+      &nbsp;&nbsp;&nbsp;&mdash; <em>Packing</em> shrinks the gap between <code>scheduler booked</code> and <code>VM capacity</code>. Visible as &ldquo;VM slack&rdquo; in the capacity mix.<br>
+      &nbsp;&nbsp;&nbsp;&mdash; <em>Provisioning</em> shrinks <code>VM capacity</code> itself (picking smaller/cheaper instances). Visible as a shorter total bar.<br>
+      Rightsizing does <em>not</em> directly raise Real VM efficiency &mdash; it only frees VM headroom for packing/provisioning to consume.
+    </p>
+    <div class="callout">
+      <div class="callout-header" onclick="this.nextElementSibling.classList.toggle('show')">
+        &#9654; Scheduler strategy by run group
+      </div>
+      <div class="callout-body show" style="overflow-x:auto">
+        <table class="gs-table" id="strategy-table"></table>
+      </div>
+    </div>
+    <p class="section-desc">
+      <strong>Note on Predv1 visibility.</strong> The per-task <code>cpus</code> value in the Nextflow trace is always the Nextflow <em>config</em> request, not the scheduler-submitted value. Rightsizing savings are therefore derived from aggregate <code>/machines</code> utilization, which is lossy: when Predv1&rsquo;s rightsizing is small relative to scheduler-side overhead (ramp-up, handoff between tasks on the same VM, concurrent-task edge cases), the aggregate can show <code>scheduler booked &geq; user requested</code> and the rightsize layer clamps to 0. This is an under-count, not a correctness bug &mdash; per-task scheduler-booked CPU / memory from a <code>/v1a1/compute/tasks/{id}</code> response would make it exact. A staging/retry layer using <code>duration</code> is intentionally omitted &mdash; on spot runs it silently bundles staging with interrupted-VM and retry-queue time.
+    </p>
+
+    <h2 id="pg-cpu-mix"><svg class="h-icon sm"><use href="#ic-chart"/></svg> Capacity mix (CPU)</h2>
+    <p class="section-desc">Each bar spans the total VM vCPU-hours paid for. Segments show how those hours were spent.</p>
+    <div class="chart" id="chart-pg-cpu-mix"></div>
+
+    <h2 id="pg-mem-mix"><svg class="h-icon sm"><use href="#ic-chart"/></svg> Capacity mix (Memory)</h2>
+    <p class="section-desc">Each bar spans the total VM memory GiB-hours paid for.</p>
+    <div class="chart" id="chart-pg-mem-mix"></div>
+
+    <h2 id="pg-cpu-savings"><svg class="h-icon sm"><use href="#ic-chart"/></svg> Savings attribution (CPU)</h2>
+    <p class="section-desc">
+      vCPU-hours attributable to each layer.<br>
+      <em>Scheduler rightsize</em> (green): max(0, &Sigma;cpus<sub>config</sub>&middot;realtime &minus; scheduler booked). Savings Predv1 has <em>already</em> realized. &asymp;0 for no-prediction runs and AWS Batch.<br>
+      <em>Task overbook</em> (blue): scheduler booked &minus; &Sigma;(pcpu/100 &middot; realtime). Scheduler still booked more CPU than tasks used.<br>
+      <em>VM packing slack</em> (grey): VM capacity &minus; scheduler booked. VM capacity not booked to any task.
+    </p>
+    <div class="chart" id="chart-pg-cpu-savings"></div>
+
+    <h2 id="pg-mem-savings"><svg class="h-icon sm"><use href="#ic-chart"/></svg> Savings attribution (Memory)</h2>
+    <div class="chart" id="chart-pg-mem-savings"></div>
+  </div>
+
+</div>
+</div>
+
+<footer>
+  <div class="container">
+    Generated by <a href="https://github.com/seqeralabs/nf-aggregate">seqeralabs/nf-aggregate</a> &mdash;
+    Powered by <a href="https://seqera.io">Seqera</a>
+  </div>
+</footer>
+
+<script>
+echarts.registerTheme('seqera', {
+    "color": [
+        "#087F68",
+        "#45a1bf",
+        "#201637",
+        "#f4b548",
+        "#31C9AC",
+        "#8f3d56",
+        "#85c7c6",
+        "#a5cdee",
+        "#d2c6ac",
+        "#46a485"
+    ],
+    "backgroundColor": "#ffffff",
+    "textStyle": {
+        "color": "#201637",
+        "fontFamily": "'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+        "fontSize": 12
+    },
+    "title": {
+        "textStyle": {
+            "color": "#201637",
+            "fontSize": 14,
+            "fontWeight": 500
+        },
+        "subtextStyle": {
+            "color": "#087F68",
+            "fontSize": 12
+        },
+        "padding": 0,
+        "itemGap": 7,
+        "top": "1px",
+        "left": "center"
+    },
+    "grid": {
+        "left": "1%",
+        "right": "4%",
+        "bottom": "0%",
+        "top": "15%",
+        "containLabel": true
+    },
+    "legend": {
+        "textStyle": {
+            "color": "#666",
+            "fontSize": 11
+        },
+        "icon": "circle",
+        "padding": [0, 0, 0, -7],
+        "animationDurationUpdate": 300
+    },
+    "tooltip": {
+        "borderRadius": 4,
+        "borderWidth": 1,
+        "borderColor": "#CFD0D1",
+        "textStyle": {
+            "fontSize": 12,
+            "fontWeight": 400,
+            "color": "#201637"
+        },
+        "padding": [6, 8],
+        "backgroundColor": "rgba(255,255,255,0.96)",
+        "axisPointer": {
+            "lineStyle": {
+                "color": "#CFD0D1",
+                "width": 1
+            },
+            "crossStyle": {
+                "color": "#CFD0D1",
+                "width": 1
+            },
+            "label": {
+                "color": "#ffffff",
+                "backgroundColor": "#201637"
+            }
+        }
+    },
+    "toolbox": {
+        "iconStyle": {
+            "borderColor": "#087F68"
+        },
+        "emphasis": {
+            "iconStyle": {
+                "borderColor": "#31C9AC"
+            }
+        }
+    },
+    "animationDuration": 500,
+    "animationDurationUpdate": 500,
+    "dataZoom": {
+        "borderColor": "#CFD0D1",
+        "textStyle": {
+            "color": "#201637"
+        },
+        "brushStyle": {
+            "color": "rgba(8,127,104,0.15)"
+        },
+        "handleStyle": {
+            "color": "#087F68",
+            "borderColor": "#CFD0D1"
+        },
+        "moveHandleStyle": {
+            "color": "#31C9AC",
+            "opacity": 0.5
+        },
+        "fillerColor": "rgba(49,201,172,0.15)",
+        "emphasis": {
+            "handleStyle": {
+                "borderColor": "#087F68",
+                "color": "#31C9AC"
+            },
+            "moveHandleStyle": {
+                "color": "#087F68",
+                "opacity": 0.7
+            }
+        },
+        "dataBackground": {
+            "lineStyle": {
+                "color": "#CFD0D1",
+                "width": 1
+            },
+            "areaStyle": {
+                "color": "#E2F7F3"
+            }
+        },
+        "selectedDataBackground": {
+            "lineStyle": {
+                "color": "#087F68"
+            },
+            "areaStyle": {
+                "color": "#31C9AC"
+            }
+        }
+    },
+    "visualMap": {
+        "textStyle": {
+            "color": "#201637"
+        },
+        "inRange": {
+            "color": ["#E2F7F3", "#31C9AC", "#087F68"]
+        }
+    },
+    "timeline": {
+        "lineStyle": {
+            "color": "#CFD0D1"
+        },
+        "itemStyle": {
+            "color": "#31C9AC",
+            "borderColor": "#087F68"
+        },
+        "label": {
+            "color": "#201637"
+        },
+        "controlStyle": {
+            "color": "#087F68",
+            "borderColor": "#087F68"
+        },
+        "emphasis": {
+            "itemStyle": {
+                "color": "#087F68"
+            },
+            "controlStyle": {
+                "color": "#087F68",
+                "borderColor": "#087F68"
+            }
+        }
+    },
+    "calendar": {
+        "itemStyle": {
+            "color": "#ffffff",
+            "borderColor": "#CFD0D1"
+        },
+        "dayLabel": {
+            "color": "#201637"
+        },
+        "monthLabel": {
+            "color": "#201637"
+        },
+        "yearLabel": {
+            "color": "#201637"
+        }
+    },
+    "categoryAxis": {
+        "axisLine": {
+            "show": true,
+            "lineStyle": {
+                "color": "#CFD0D1"
+            }
+        },
+        "axisTick": {
+            "show": false
+        },
+        "axisLabel": {
+            "color": "#666",
+            "fontSize": 11
+        },
+        "splitLine": {
+            "show": false,
+            "lineStyle": {
+                "color": ["#CFD0D1"]
+            }
+        },
+        "splitArea": {
+            "areaStyle": {
+                "color": ["#ffffff", "#F7F7F7"]
+            }
+        }
+    },
+    "valueAxis": {
+        "axisLine": {
+            "show": false
+        },
+        "axisTick": {
+            "show": false
+        },
+        "axisLabel": {
+            "color": "#666",
+            "fontSize": 11
+        },
+        "splitLine": {
+            "show": true,
+            "lineStyle": {
+                "color": "#E8E8E8",
+                "width": 1
+            }
+        },
+        "splitArea": {
+            "areaStyle": {
+                "color": ["#ffffff", "#F7F7F7"]
+            }
+        },
+        "nameTextStyle": {
+            "color": "#666",
+            "fontSize": 11
+        }
+    },
+    "logAxis": {
+        "axisLine": {
+            "show": false
+        },
+        "axisTick": {
+            "show": false
+        },
+        "axisLabel": {
+            "color": "#666"
+        },
+        "splitLine": {
+            "show": true,
+            "lineStyle": {
+                "color": "#E8E8E8",
+                "width": 1
+            }
+        }
+    },
+    "timeAxis": {
+        "axisLine": {
+            "show": true,
+            "lineStyle": {
+                "color": "#CFD0D1"
+            }
+        },
+        "axisTick": {
+            "show": false
+        },
+        "axisLabel": {
+            "color": "#666"
+        },
+        "splitLine": {
+            "show": true,
+            "lineStyle": {
+                "color": "#E8E8E8",
+                "width": 1
+            }
+        }
+    },
+    "line": {
+        "itemStyle": {
+            "borderWidth": 2
+        },
+        "lineStyle": {
+            "width": 2
+        },
+        "symbolSize": 6,
+        "symbol": "circle",
+        "smooth": false
+    },
+    "bar": {
+        "itemStyle": {
+            "barBorderWidth": 0,
+            "barBorderColor": "#ffffff",
+            "borderRadius": [2, 2, 2, 2]
+        },
+        "barMaxWidth": 60,
+        "emphasis": {
+            "focus": "series"
+        },
+        "labelLayout": {
+            "hideOverlap": true
+        }
+    },
+    "pie": {
+        "itemStyle": {
+            "borderWidth": 1,
+            "borderColor": "#ffffff"
+        }
+    },
+    "scatter": {
+        "itemStyle": {
+            "borderWidth": 0
+        },
+        "symbolSize": 8,
+        "emphasis": {
+            "focus": "series"
+        }
+    },
+    "boxplot": {
+        "itemStyle": {
+            "color": "#E2F7F3",
+            "borderColor": "#087F68",
+            "borderWidth": 1.5
+        }
+    },
+    "graph": {
+        "itemStyle": {
+            "borderWidth": 0
+        },
+        "lineStyle": {
+            "width": 1,
+            "color": "#CFD0D1"
+        },
+        "label": {
+            "color": "#201637"
+        }
+    },
+    "gauge": {
+        "title": {
+            "color": "#201637"
+        },
+        "itemStyle": {
+            "color": "#31C9AC",
+            "borderColor": "#087F68"
+        },
+        "axisLine": {
+            "lineStyle": {
+                "color": [
+                    [0.2, "#31C9AC"],
+                    [0.8, "#087F68"],
+                    [1, "#201637"]
+                ]
+            }
+        },
+        "detail": {
+            "color": "#087F68"
+        }
+    },
+    "candlestick": {
+        "itemStyle": {
+            "color": "#31C9AC",
+            "color0": "#201637",
+            "borderColor": "#087F68",
+            "borderColor0": "#201637"
+        }
+    }
+}
+);
+
+const DATA = __REPORT_DATA__;
+const COLORS = ["#065647", "#45a1bf", "#201637", "#f4b548", "#31C9AC", "#8f3d56", "#85c7c6", "#a5cdee", "#d2c6ac", "#46a485"];
+
+function fmtDuration(ms) {
+  if (ms == null || ms === 0) return '\u2014';
+  const h = Math.floor(ms / 3600000);
+  const m = Math.floor((ms % 3600000) / 60000);
+  const s = Math.floor((ms % 60000) / 1000);
+  if (h > 0) return h + ':' + String(m).padStart(2,'0') + ':' + String(s).padStart(2,'0');
+  return m + ':' + String(s).padStart(2,'0');
+}
+function fmtCost(v) { return v != null ? '$' + Number(v).toFixed(2) : '\u2014'; }
+function fmtPct(v) { return v != null ? Number(v).toFixed(1) + '%' : '\u2014'; }
+function fmtGB(v) { return v != null ? Number(v).toLocaleString() : '\u2014'; }
+function fmtHours(v) { return v != null ? Number(v).toFixed(1) : '\u2014'; }
+
+function takeaway(labels, values, opts) {
+  opts = opts || {};
+  if (values.length < 2) return '';
+  const pairs = labels.map((l, i) => ({ label: l, value: values[i] })).filter(p => p.value != null);
+  if (pairs.length < 2) return '';
+  pairs.sort((a, b) => a.value - b.value);
+  const lo = pairs[0], hi = pairs[pairs.length - 1];
+  if (hi.value === 0) return '';
+  const ratio = (hi.value / lo.value).toFixed(1);
+  const prefix = opts.prefix || '';
+  const suffix = opts.suffix || '';
+  if (opts.lowerBetter) {
+    return lo.label + ' was ' + ratio + '\u00d7 ' + (opts.adjective || 'lower') + ' (' + prefix + lo.value.toLocaleString(undefined, {maximumFractionDigits: 1}) + suffix + ' vs ' + prefix + hi.value.toLocaleString(undefined, {maximumFractionDigits: 1}) + suffix + ')';
+  }
+  return hi.label + ' was ' + ratio + '\u00d7 ' + (opts.adjective || 'higher') + ' (' + prefix + hi.value.toLocaleString(undefined, {maximumFractionDigits: 1}) + suffix + ' vs ' + prefix + lo.value.toLocaleString(undefined, {maximumFractionDigits: 1}) + suffix + ')';
+}
+
+function downloadCSV(tableId, filename) {
+  const table = document.getElementById(tableId);
+  const rows = [...table.querySelectorAll('tr')];
+  const csv = rows.map(r => [...r.querySelectorAll('th,td')].map(c => '"'+c.textContent.trim()+'"').join(',')).join('\n');
+  const blob = new Blob([csv], {type:'text/csv'});
+  const a = document.createElement('a'); a.href = URL.createObjectURL(blob);
+  a.download = filename; a.click();
+}
+
+// Group colors
+const groups = [...new Set((DATA.run_summary||[]).map(r => r.group))];
+const groupColor = {};
+groups.forEach((g,i) => { groupColor[g] = COLORS[i % COLORS.length]; });
+
+document.getElementById('group-list').innerHTML = groups.map(g =>
+  `<span style="background:${groupColor[g]}"></span>${g}`
+).join(' &nbsp; ');
+
+// Scheduler strategy matrix
+(function() {
+  const runs = DATA.run_summary || [];
+  const table = document.getElementById('strategy-table');
+  if (!runs.length || !table) return;
+  const rows = runs
+    .map(r => ({
+      group: r.group,
+      scheduler_mode: r.scheduler_mode || '\u2014',
+      task_rightsizing: r.task_rightsizing || '\u2014',
+      packing: r.packing || '\u2014',
+      vm_provisioning: r.vm_provisioning || '\u2014',
+    }))
+    .filter((row, idx, arr) => idx === arr.findIndex(x => x.group === row.group));
+
+  let html = '<thead><tr><th>Group</th><th>Control plane</th><th>Task rightsizing</th><th>Packing</th><th>VM provisioning</th></tr></thead><tbody>';
+  rows.forEach(r => {
+    html += '<tr>';
+    html += '<td>' + r.group + '</td>';
+    html += '<td>' + r.scheduler_mode + '</td>';
+    html += '<td>' + r.task_rightsizing + '</td>';
+    html += '<td>' + r.packing + '</td>';
+    html += '<td>' + r.vm_provisioning + '</td>';
+    html += '</tr>';
+  });
+  html += '</tbody>';
+  table.innerHTML = html;
+})();
+
+// 1. Benchmark overview matrix
+(function() {
+  const runs = DATA.benchmark_overview || [];
+  const pipelines = [...new Set(runs.map(r => r.pipeline))];
+  const table = document.getElementById('overview-matrix');
+  let html = '<thead><tr><th style="text-align:left">Pipeline</th>';
+  groups.forEach(g => { html += `<th>${g}</th>`; });
+  html += '</tr></thead><tbody>';
+  pipelines.forEach(p => {
+    html += '<tr><td>' + p + '</td>';
+    groups.forEach(g => {
+      const match = runs.find(r => r.pipeline === p && r.group === g);
+      let cell = '\u2014';
+      if (match) {
+        cell = match.platform_url
+          ? `<a href="${match.platform_url}" target="_blank" rel="noopener">${match.run_id}</a>`
+          : match.run_id;
+      }
+      html += '<td>' + cell + '</td>';
+    });
+    html += '</tr>';
+  });
+  html += '</tbody>';
+  table.innerHTML = html;
+})();
+
+// 2.1 Run summary table (with cached tasks)
+(function() {
+  const runs = DATA.run_summary || [];
+  if (!runs.length) return;
+  const cols = [
+    ['Pipeline name','pipeline'], ['Group','group'], ['Run ID','run_id'],
+    ['User name','username'], ['Pipeline version','Version'],
+    ['Nextflow version','Nextflow_version'], ['Platform version','platform_version'],
+    ['Tasks succeeded','succeedCount'], ['Tasks failed','failedCount'],
+    ['Tasks cached','cachedCount'],
+    ['Executor','executor'], ['Region','region'],
+    ['Fusion enabled','fusion_enabled'], ['Wave enabled','wave_enabled'],
+  ];
+  const table = document.getElementById('run-summary-table');
+  let html = '<thead><tr>' + cols.map(c => '<th>'+c[0]+'</th>').join('') + '</tr></thead><tbody>';
+  runs.forEach((r,i) => {
+    const bg = groupColor[r.group] || '#CFD0D1';
+    html += `<tr style="background:${bg}22">`;
+    cols.forEach(c => { html += '<td>' + (r[c[1]] != null ? r[c[1]] : '\u2014') + '</td>'; });
+    html += '</tr>';
+  });
+  html += '</tbody>';
+  table.innerHTML = html;
+})();
+
+// 2.2 Run metrics table
+(function() {
+  const metrics = DATA.run_metrics || [];
+  const costs = DATA.run_costs || [];
+  if (!metrics.length) return;
+  const table = document.getElementById('run-metrics-table');
+  const cols = ['Pipeline name','Group','Run ID','Duration','CPU time (hours)',
+                'Compute cost ($)','Read (GB)','Write (GB)',
+                'Trace CPU eff (task) %','Trace Mem eff (task) %',
+                'Sched alloc CPU (VM) %','Sched alloc Mem (VM) %',
+                'Real VM CPU eff %','Real VM Mem eff %',
+                'Used cost ($)','Unused cost ($)','Total task runtime'];
+  let html = '<thead><tr>' + cols.map(c => '<th>'+c+'</th>').join('') + '</tr></thead><tbody>';
+  metrics.forEach(r => {
+    const c = costs.find(x => x.run_id === r.run_id) || {};
+    const pipelineRuntimeMs = r.task_runtime_ms || r.pipeline_runtime || 0;
+    const prtH = Math.floor(pipelineRuntimeMs / 3600000);
+    const prtM = Math.floor((pipelineRuntimeMs % 3600000) / 60000);
+    const prtS = Math.floor((pipelineRuntimeMs % 60000) / 1000);
+    const prtFmt = prtH + ':' + String(prtM).padStart(2,'0') + ':' + String(prtS).padStart(2,'0');
+    html += '<tr>';
+    html += '<td>' + r.pipeline + '</td>';
+    html += '<td>' + r.group + '</td>';
+    html += '<td>' + r.run_id + '</td>';
+    html += '<td>' + fmtDuration(r.duration) + '</td>';
+    html += '<td>' + fmtHours(r.cpuTime) + '</td>';
+    html += '<td>' + fmtCost(c.cost) + '</td>';
+    html += '<td>' + fmtGB(r.readBytes) + '</td>';
+    html += '<td>' + fmtGB(r.writeBytes) + '</td>';
+    html += '<td>' + fmtPct(r.cpuEfficiency) + '</td>';
+    html += '<td>' + fmtPct(r.memoryEfficiency) + '</td>';
+    html += '<td>' + fmtPct(r.schedAllocCpuEfficiency) + '</td>';
+    html += '<td>' + fmtPct(r.schedAllocMemEfficiency) + '</td>';
+    html += '<td>' + fmtPct(r.realVmCpuEfficiency) + '</td>';
+    html += '<td>' + fmtPct(r.realVmMemEfficiency) + '</td>';
+    html += '<td>' + fmtCost(c.used_cost) + '</td>';
+    html += '<td>' + fmtCost(c.unused_cost) + '</td>';
+    html += '<td>' + prtFmt + '</td>';
+    html += '</tr>';
+  });
+  html += '</tbody>';
+  table.innerHTML = html;
+})();
+
+// Chart helpers
+function hbarChart(elId, title, labels, values, opts) {
+  opts = opts || {};
+  const el = document.getElementById(elId);
+  if (!el) return;
+  const height = Math.max(250, labels.length * 45 + 80);
+  el.style.height = height + 'px';
+  const seriesArray = opts.series || [{ type: 'bar', data: values.slice().reverse(),
+    itemStyle: opts.color ? { color: opts.color, borderRadius: [0, 2, 2, 0] }
+                          : { borderRadius: [0, 2, 2, 0] },
+    emphasis: { focus: 'series' } }];
+  if (seriesArray.length > 1 && seriesArray.length <= 3) {
+    seriesArray.forEach(s => {
+      s.label = { show: true, position: 'right', formatter: '{a}' };
+    });
+  }
+  echarts.init(el, 'seqera').setOption({
+    title: { text: title, subtext: opts.subtitle || '' },
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' },
+      formatter: opts.formatter || (p => p[0].name + ': ' + (opts.prefix||'') +
+        p[0].value.toLocaleString(undefined, {maximumFractionDigits:2}) + (opts.suffix||'')) },
+    grid: { top: opts.subtitle ? 60 : 40, bottom: 30, containLabel: true },
+    xAxis: { type: 'value', name: opts.xName || '', nameLocation: 'center',
+      nameGap: 25, axisLabel: { hideOverlap: true } },
+    yAxis: { type: 'category', data: labels.slice().reverse() },
+    series: seriesArray,
+  });
+}
+
+function hbarStacked(elId, title, labels, seriesDefs, opts) {
+  opts = opts || {};
+  const el = document.getElementById(elId);
+  if (!el) return;
+  const height = Math.max(250, labels.length * 45 + 80);
+  el.style.height = height + 'px';
+  echarts.init(el, 'seqera').setOption({
+    title: { text: title, subtext: opts.subtitle || '' },
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { show: seriesDefs.length > 3, bottom: 0 },
+    grid: { top: opts.subtitle ? 60 : 40, bottom: 40, containLabel: true },
+    xAxis: { type: 'value', name: opts.xName || '', nameLocation: 'center', nameGap: 25, axisLabel: { hideOverlap: true } },
+    yAxis: { type: 'category', data: labels.slice().reverse() },
+    series: seriesDefs.map((s, i, arr) => ({
+      name: s.name, type: 'bar', stack: 'total',
+      data: s.data.slice().reverse(), itemStyle: { color: s.color,
+        borderRadius: i === arr.length - 1 ? [0, 2, 2, 0] : 0 },
+      emphasis: { focus: 'series' },
+      label: { show: true, position: 'inside', overflow: 'truncate', formatter: function(p) { return p.value > 5 ? p.seriesName : ''; }, fontSize: 11, color: '#fff' },
+    })),
+  });
+}
+
+// 2.2 Run metrics charts
+(function() {
+  const metrics = DATA.run_metrics || [];
+  const costs = DATA.run_costs || [];
+  const labels = metrics.map(r => r.group);
+
+  const wallValues = metrics.map(r => +(r.duration / 3600000).toFixed(2));
+  hbarChart('chart-wall-time', 'Wall time', labels, wallValues,
+    { xName: 'Hours', suffix: ' h', subtitle: takeaway(labels, wallValues, { lowerBetter: true, adjective: 'faster', suffix: ' h' }) });
+
+  const cpuValues = metrics.map(r => +(r.cpuTime || 0));
+  hbarChart('chart-cpu-time', 'CPU time', labels, cpuValues,
+    { xName: 'CPU Hours', suffix: ' h', subtitle: takeaway(labels, cpuValues, { lowerBetter: true, adjective: 'lower', suffix: ' h' }) });
+
+  const costValues = metrics.map(r => { const c = costs.find(x => x.run_id === r.run_id); return c ? +c.cost : 0; });
+  hbarChart('chart-est-cost', 'Compute cost', labels, costValues,
+    { xName: '$', prefix: '$', subtitle: takeaway(labels, costValues, { lowerBetter: true, adjective: 'cheaper', prefix: '$' }) });
+
+  // Workflow status — succeeded/failed/cached stacked bars
+  const summaryRuns = DATA.run_summary || [];
+  const totalSucc = summaryRuns.reduce((s,r) => s + (r.succeedCount||0), 0);
+  const totalFail = summaryRuns.reduce((s,r) => s + (r.failedCount||0), 0);
+  const totalCached = summaryRuns.reduce((s,r) => s + (r.cachedCount||0), 0);
+  let statusSubtitle = '';
+  if (totalFail === 0 && totalCached === 0) {
+    statusSubtitle = 'All tasks succeeded';
+  } else {
+    const parts = [];
+    if (totalFail > 0) parts.push(totalFail + ' task' + (totalFail > 1 ? 's' : '') + ' failed');
+    if (totalCached > 0) parts.push(totalCached + ' task' + (totalCached > 1 ? 's' : '') + ' cached');
+    statusSubtitle = parts.join(', ') + ' across all runs';
+  }
+  const statusSeries = [
+    { name: 'Succeeded', data: summaryRuns.map(r => r.succeedCount || 0), color: '#16a34a' },
+    { name: 'Failed', data: summaryRuns.map(r => r.failedCount || 0), color: '#dc2626' },
+  ];
+  if (totalCached > 0) {
+    statusSeries.push(
+      { name: 'Cached', data: summaryRuns.map(r => r.cachedCount || 0), color: '#f59e0b' }
+    );
+  }
+  hbarStacked('chart-workflow-status', 'Workflow status', labels, statusSeries,
+    { xName: 'Tasks', subtitle: statusSubtitle });
+
+  const cpuEffValues = metrics.map(r => +(r.cpuEfficiency || 0));
+  hbarChart('chart-cpu-eff', 'Trace CPU efficiency (task)', labels, cpuEffValues,
+    { xName: '%', suffix: '%', subtitle: takeaway(labels, cpuEffValues, { adjective: 'more efficient', suffix: '%' }) });
+  const memEffValues = metrics.map(r => +(r.memoryEfficiency || 0));
+  hbarChart('chart-mem-eff', 'Trace Memory efficiency (task)', labels, memEffValues,
+    { xName: '%', suffix: '%', subtitle: takeaway(labels, memEffValues, { adjective: 'more efficient', suffix: '%' }) });
+
+  const hasVmMetrics = metrics.some(r => r.schedAllocCpuEfficiency != null || r.realVmCpuEfficiency != null);
+  if (hasVmMetrics) {
+    const allocCpu = metrics.map(r => +(r.schedAllocCpuEfficiency || 0));
+    hbarChart('chart-vm-alloc-cpu', 'Sched allocation CPU (VM booking)', labels, allocCpu,
+      { xName: '%', suffix: '%', subtitle: takeaway(labels, allocCpu, { adjective: 'better packed', suffix: '%' }) });
+    const allocMem = metrics.map(r => +(r.schedAllocMemEfficiency || 0));
+    hbarChart('chart-vm-alloc-mem', 'Sched allocation Memory (VM booking)', labels, allocMem,
+      { xName: '%', suffix: '%', subtitle: takeaway(labels, allocMem, { adjective: 'better packed', suffix: '%' }) });
+    const realCpu = metrics.map(r => +(r.realVmCpuEfficiency || 0));
+    hbarChart('chart-vm-real-cpu', 'Real VM CPU efficiency', labels, realCpu,
+      { xName: '%', suffix: '%', subtitle: takeaway(labels, realCpu, { adjective: 'more VM-efficient', suffix: '%' }) });
+    const realMem = metrics.map(r => +(r.realVmMemEfficiency || 0));
+    hbarChart('chart-vm-real-mem', 'Real VM Memory efficiency', labels, realMem,
+      { xName: '%', suffix: '%', subtitle: takeaway(labels, realMem, { adjective: 'more VM-efficient', suffix: '%' }) });
+  } else {
+    ['chart-vm-alloc-cpu','chart-vm-alloc-mem','chart-vm-real-cpu','chart-vm-real-mem'].forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.style.display = 'none';
+    });
+  }
+
+  const readValues = metrics.map(r => +(r.readBytes || 0));
+  hbarChart('chart-read-io', 'Data read', labels, readValues,
+    { xName: 'GB', suffix: ' GB', subtitle: takeaway(labels, readValues, { lowerBetter: true, adjective: 'less I/O', suffix: ' GB' }) });
+  const writeValues = metrics.map(r => +(r.writeBytes || 0));
+  hbarChart('chart-write-io', 'Data written', labels, writeValues,
+    { xName: 'GB', suffix: ' GB', subtitle: takeaway(labels, writeValues, { lowerBetter: true, adjective: 'less I/O', suffix: ' GB' }) });
+})();
+
+// 5. Performance gains — capacity mix + savings attribution
+(function() {
+  const metrics = (DATA.run_metrics || []).filter(r => (r.vmCpuH || 0) > 0);
+  ['chart-pg-cpu-mix','chart-pg-mem-mix','chart-pg-cpu-savings','chart-pg-mem-savings'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el && !metrics.length) el.style.display = 'none';
+  });
+  if (!metrics.length) return;
+
+  const labels = metrics.map(r => r.group);
+
+  const C_USED = '#065647';
+  const C_BOOKED = '#2b8cbe';
+  const C_VM   = '#cfd0d1';
+
+  function mix(field) {
+    const used = [], schedExcess = [], vmSl = [];
+    metrics.forEach(r => {
+      const vm = Math.max(0, +r['vm' + field] || 0);
+      const usedKey = field === 'CpuH' ? 'realCpuH' : 'realMemGibH';
+      const overbookKey = field === 'CpuH' ? 'schedulerOverbookCpuH' : 'schedulerOverbookMemGibH';
+      const slackKey = field === 'CpuH' ? 'vmPackingSlackCpuH' : 'vmPackingSlackMemGibH';
+      const u = Math.max(0, +r[usedKey] || 0);
+      const ex = Math.max(0, +r[overbookKey] || 0);
+      const sl = Math.max(0, +r[slackKey] || 0);
+      const total = u + ex + sl;
+      const scale = total > vm && vm > 0 ? vm / total : 1;
+      used.push(+(u * scale).toFixed(2));
+      schedExcess.push(+(ex * scale).toFixed(2));
+      vmSl.push(+(sl * scale).toFixed(2));
+    });
+    return [
+      { name: 'Used (real work)', data: used, color: C_USED },
+      { name: 'Scheduler over-booked (vs used)', data: schedExcess, color: C_BOOKED },
+      { name: 'VM slack (packing)', data: vmSl, color: C_VM },
+    ];
+  }
+
+  const cpuMix = mix('CpuH');
+  hbarStacked('chart-pg-cpu-mix', 'CPU capacity mix', labels, cpuMix,
+    { xName: 'vCPU-hours', subtitle: 'Total bar = VM vCPU-hours paid for' });
+
+  const memMix = mix('MemGibH');
+  hbarStacked('chart-pg-mem-mix', 'Memory capacity mix', labels, memMix,
+    { xName: 'GiB-hours', subtitle: 'Total bar = VM memory GiB-hours paid for' });
+
+  // Savings vertical bars — three layers, per run:
+  //   schedRightsize = max(0, user_req − sched_booked)
+  //                    Saved *already* by Predv1 prediction (≈0 for no-pred).
+  //   taskOverbook   = max(0, sched_booked − used)
+  //                    Scheduler booked more than the task actually used (still wasted).
+  //   vmPacking      = max(0, vm_cap − sched_booked)
+  //                    VM capacity not booked by any task.
+  const C_RS    = '#43b48d';   // green — already saved
+  const C_OVERB = C_BOOKED;    // blue — still wasted at task level
+  const C_PACK  = C_VM;        // grey — still wasted at VM level
+
+  function savingsChart(elId, title, field, yName) {
+    const el = document.getElementById(elId);
+    if (!el) return;
+    const schedRightsize = [], taskOverbook = [], vmPacking = [];
+    metrics.forEach(r => {
+      const rightsizeKey = field === 'CpuH' ? 'schedulerRightsizedCpuH' : 'schedulerRightsizedMemGibH';
+      const overbookKey = field === 'CpuH' ? 'schedulerOverbookCpuH' : 'schedulerOverbookMemGibH';
+      const slackKey = field === 'CpuH' ? 'vmPackingSlackCpuH' : 'vmPackingSlackMemGibH';
+      schedRightsize.push(+Math.max(0, +r[rightsizeKey] || 0).toFixed(2));
+      taskOverbook.push(+Math.max(0, +r[overbookKey] || 0).toFixed(2));
+      vmPacking.push(+Math.max(0, +r[slackKey] || 0).toFixed(2));
+    });
+    el.style.height = Math.max(300, labels.length * 55 + 100) + 'px';
+    echarts.init(el, 'seqera').setOption({
+      title: { text: title },
+      tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+      legend: { bottom: 0 },
+      grid: { top: 40, bottom: 60, containLabel: true },
+      xAxis: { type: 'category', data: labels },
+      yAxis: { type: 'value', name: yName, nameLocation: 'center', nameGap: 45 },
+      series: [
+        { name: 'Scheduler rightsize (already saved)', type: 'bar', stack: 'waste', data: schedRightsize, itemStyle: { color: C_RS } },
+        { name: 'Task overbook (remaining)',           type: 'bar', stack: 'waste', data: taskOverbook,   itemStyle: { color: C_OVERB } },
+        { name: 'VM packing slack',                    type: 'bar', stack: 'waste', data: vmPacking,      itemStyle: { color: C_PACK } },
+      ],
+    });
+  }
+  savingsChart('chart-pg-cpu-savings', 'Savings attribution (CPU) by layer', 'CpuH', 'vCPU-hours');
+  savingsChart('chart-pg-mem-savings', 'Savings attribution (Memory) by layer', 'MemGibH', 'GiB-hours');
+})();
+
+// 3. Process overview
+(function() {
+  const stats = DATA.process_stats || [];
+  if (!stats.length) return;
+
+  const pipelines = [...new Set(stats.map(s => {
+    const parts = s.process_name.split(':');
+    return parts.length > 1 ? parts[0].replace('NFCORE_','').toLowerCase() : 'default';
+  }))];
+
+  const container = document.getElementById('process-sections');
+
+  pipelines.forEach(pipeline => {
+    const pipelineStats = stats.filter(s => {
+      const parts = s.process_name.split(':');
+      const p = parts.length > 1 ? parts[0].replace('NFCORE_','').toLowerCase() : 'default';
+      return p === pipeline;
+    });
+
+    const processes = [...new Set(pipelineStats.map(s => s.process_name))];
+
+    const section = document.createElement('div');
+    section.innerHTML = `<h3>${pipeline}</h3>`;
+
+    const rtEl = document.createElement('div');
+    rtEl.className = 'chart';
+    rtEl.style.height = Math.max(400, processes.length * 25 + 120) + 'px';
+    section.appendChild(rtEl);
+    container.appendChild(section);
+
+    const series = groups.map((g, gi) => {
+      const gStats = pipelineStats.filter(s => s.group === g);
+      return {
+        name: g, type: 'scatter', symbolSize: 8,
+        itemStyle: { color: groupColor[g] },
+        data: processes.map((p, pi) => {
+          const s = gStats.find(x => x.process_name === p);
+          return s ? [s.avg_runtime_min, pi] : null;
+        }).filter(Boolean),
+        markPoint: groups.length <= 3 ? {
+          data: [{ type: 'max', valueDim: 'x' }],
+          label: { formatter: g, fontSize: 10, position: 'right', color: groupColor[g] },
+          symbolSize: 0
+        } : undefined,
+      };
+    });
+
+    const errorSeries = groups.map((g, gi) => {
+      const gStats = pipelineStats.filter(s => s.group === g);
+      return {
+        name: g + ' (\u00b1SD)', type: 'custom', silent: true,
+        renderItem: function(params, api) {
+          const yVal = api.value(1);
+          const xVal = api.value(0);
+          const sd = api.value(2);
+          const point = api.coord([xVal, yVal]);
+          const lo = api.coord([Math.max(0, xVal - sd), yVal]);
+          const hi = api.coord([xVal + sd, yVal]);
+          return { type: 'group', children: [
+            { type: 'line', shape: { x1: lo[0], y1: point[1], x2: hi[0], y2: point[1] },
+              style: { stroke: groupColor[g], lineWidth: 1.5 } },
+            { type: 'line', shape: { x1: lo[0], y1: point[1]-4, x2: lo[0], y2: point[1]+4 },
+              style: { stroke: groupColor[g], lineWidth: 1.5 } },
+            { type: 'line', shape: { x1: hi[0], y1: point[1]-4, x2: hi[0], y2: point[1]+4 },
+              style: { stroke: groupColor[g], lineWidth: 1.5 } },
+          ]};
+        },
+        data: processes.map((p, pi) => {
+          const s = gStats.find(x => x.process_name === p);
+          return s ? [s.avg_runtime_min, pi, s.sd_runtime_min || 0] : null;
+        }).filter(Boolean),
+        encode: { x: 0, y: 1 },
+        z: -1,
+      };
+    });
+
+    const costEl = document.createElement('div');
+    costEl.className = 'chart';
+    costEl.style.height = Math.max(400, processes.length * 25 + 120) + 'px';
+    section.appendChild(costEl);
+
+    const costSeries = groups.map((g, gi) => {
+      const gStats = pipelineStats.filter(s => s.group === g);
+      return {
+        name: g, type: 'bar', stack: g,
+        itemStyle: { color: groupColor[g], borderRadius: [0, 2, 2, 0] },
+        emphasis: { focus: 'series' },
+        label: { show: groups.length <= 3, position: 'right', formatter: '{a}', fontSize: 10 },
+        data: processes.map(p => {
+          const s = gStats.find(x => x.process_name === p);
+          return s ? +s.total_cost.toFixed(4) : 0;
+        }),
+        markLine: gi === 0 ? {
+          silent: true,
+          data: [{ type: 'max', name: 'Most expensive' }],
+          label: { formatter: 'Most expensive', position: 'middle', fontSize: 10 },
+          lineStyle: { type: 'dashed', color: '#999' }
+        } : undefined
+      };
+    });
+
+    setTimeout(() => {
+      echarts.init(rtEl, 'seqera').setOption({
+        title: { text: 'Run time per process' },
+        tooltip: { trigger: 'item',
+          formatter: p => {
+            if (p.seriesType === 'custom') return '';
+            return `<strong>${processes[p.data[1]]}</strong><br>${p.seriesName}: ${p.data[0].toFixed(1)} min`;
+          }
+        },
+        legend: { show: groups.length > 3, data: groups, bottom: 0 },
+        grid: { top: 40, bottom: 40, containLabel: true },
+        xAxis: { type: 'value', name: 'Run time (minutes)', nameLocation: 'center', nameGap: 25 },
+        yAxis: { type: 'category', data: processes,
+                 axisLabel: { width: 280, overflow: 'truncate' },
+                 inverse: true },
+        series: [...series, ...errorSeries],
+      });
+
+      echarts.init(costEl, 'seqera').setOption({
+        title: { text: 'Total process cost ($)' },
+        tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+        legend: { show: groups.length > 3, data: groups, bottom: 0 },
+        grid: { top: 40, bottom: 40, containLabel: true },
+        xAxis: { type: 'value', name: 'Cost ($)', nameLocation: 'center', nameGap: 25 },
+        yAxis: { type: 'category', data: processes,
+                 axisLabel: { width: 280, overflow: 'truncate' },
+                 inverse: true },
+        series: costSeries,
+      });
+    }, 50);
+  });
+})();
+
+// 4.1 Task instance usage
+(function() {
+  const usage = DATA.task_instance_usage || [];
+  if (!usage.length) return;
+  const instanceTypes = [...new Set(usage.map(u => u.machine_type))];
+  const instanceColors = {};
+  instanceTypes.forEach((t,i) => { instanceColors[t] = COLORS[i % COLORS.length]; });
+
+  const el = document.getElementById('chart-instance-usage');
+  const height = Math.max(300, groups.length * 60 + 100);
+  el.style.height = height + 'px';
+
+  echarts.init(el, 'seqera').setOption({
+    title: { text: 'Instance type usage' },
+    tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+    legend: { data: instanceTypes, bottom: 0, type: 'scroll' },
+    grid: { top: 40, bottom: 60, containLabel: true },
+    xAxis: { type: 'value', name: 'Number of tasks', nameLocation: 'center', nameGap: 25 },
+    yAxis: { type: 'category', data: groups.slice().reverse() },
+    series: instanceTypes.map(t => ({
+      name: t, type: 'bar', stack: 'total',
+      emphasis: { focus: 'series' },
+      data: groups.slice().reverse().map(g => {
+        const match = usage.find(u => u.group === g && u.machine_type === t);
+        return match ? match.count : 0;
+      }),
+      itemStyle: { color: instanceColors[t] },
+    })),
+  });
+})();
+
+// 4.2 Task metrics
+(function() {
+  const tasks = DATA.task_scatter || [];
+  const taskTable = DATA.task_table || [];
+  if (!tasks.length) return;
+
+  const container = document.getElementById('task-sections');
+
+  const scatterEl = document.createElement('div');
+  scatterEl.className = 'chart';
+  scatterEl.style.height = '500px';
+  container.appendChild(scatterEl);
+
+  setTimeout(() => {
+    echarts.init(scatterEl, 'seqera').setOption({
+      title: { text: 'Task real time vs staging time' },
+      tooltip: { trigger: 'item',
+        formatter: p => `<strong>${p.data[3]}</strong><br>Real time: ${p.data[0].toFixed(1)} min<br>Staging: ${p.data[1].toFixed(1)} min<br>Cost: $${p.data[2].toFixed(4)}` },
+      legend: { show: groups.length > 3, data: groups, bottom: 0 },
+      grid: { top: 50, bottom: 60, containLabel: true },
+      xAxis: { type: 'value', name: 'Task real time (minutes)', nameLocation: 'center', nameGap: 25 },
+      yAxis: { type: 'value', name: 'Task staging time (minutes)', nameLocation: 'center', nameGap: 40 },
+      series: groups.map((g, i) => ({
+        name: g, type: 'scatter', symbolSize: 6,
+        data: tasks.filter(t => t.group === g).map(t => [t.realtime_min||0, t.staging_min||0, t.cost||0, t.process_short]),
+        itemStyle: { color: groupColor[g] },
+        markPoint: groups.length <= 3 ? {
+          data: [{ type: 'max', valueDim: 'x' }],
+          label: { formatter: g, fontSize: 10, position: 'top', color: groupColor[g] },
+          symbolSize: 0
+        } : undefined,
+      })),
+      dataZoom: [{ type: 'inside' }, { type: 'slider', bottom: 25, height: 20 }],
+    });
+  }, 100);
+
+  const costScatterEl = document.createElement('div');
+  costScatterEl.className = 'chart';
+  container.appendChild(costScatterEl);
+
+  setTimeout(() => {
+    const processes = [...new Set(tasks.map(t => t.process_short))];
+    const offsets = groups.length <= 1
+      ? { [groups[0]]: 0 }
+      : Object.fromEntries(groups.map((g, idx) => [g, ((idx / (groups.length - 1)) - 0.5) * 0.6]));
+
+    costScatterEl.style.height = Math.max(500, processes.length * 28 + 70) + 'px';
+    echarts.init(costScatterEl, 'seqera').setOption({
+      title: { text: 'Task cost ($) per process and group' },
+      tooltip: {
+        trigger: 'item',
+        formatter: p => `<strong>${p.data.process}</strong><br>${p.seriesName}<br>Cost: $${Number(p.data.value[0]).toFixed(6)}`
+      },
+      legend: { show: groups.length > 1, data: groups, bottom: 0 },
+      grid: { top: 40, bottom: 45, containLabel: true },
+      xAxis: { type: 'value', name: 'Cost ($)', nameLocation: 'center', nameGap: 25 },
+      yAxis: {
+        type: 'value',
+        min: -0.75,
+        max: Math.max(0, processes.length - 1) + 0.75,
+        axisLabel: {
+          formatter: v => {
+            const idx = Math.round(v);
+            return Number.isInteger(idx) && idx >= 0 && idx < processes.length ? processes[idx] : '';
+          }
+        },
+        splitLine: { show: false }
+      },
+      series: groups.map(g => ({
+        name: g,
+        type: 'scatter',
+        symbolSize: 7,
+        itemStyle: { color: groupColor[g] },
+        data: tasks
+          .filter(t => t.group === g && t.cost != null)
+          .map(t => ({
+            process: t.process_short,
+            value: [t.cost, processes.indexOf(t.process_short) + (offsets[g] || 0)]
+          }))
+      })),
+      dataZoom: [{ type: 'inside' }, { type: 'slider', bottom: 25, height: 16 }],
+    });
+  }, 150);
+
+  if (taskTable.length) {
+    const tableDiv = document.createElement('div');
+    tableDiv.innerHTML = `
+      <div class="callout" style="margin-top:20px">
+        <div class="callout-header" onclick="this.nextElementSibling.classList.toggle('show')">
+          &#9654; Click to display task table (${taskTable.length} tasks)
+        </div>
+        <div class="callout-body" style="overflow-x:auto;max-height:600px;overflow-y:auto">
+          <button class="csv-btn" onclick="downloadCSV('task-data-table','task_table.csv')">Download as CSV</button>
+          <table class="gs-table" id="task-data-table"></table>
+        </div>
+      </div>`;
+    container.appendChild(tableDiv);
+
+    setTimeout(() => {
+      const cols = ['Group','Run ID','Taskhash','Task name short','Executor','Cloudzone',
+                    'Instance type','Realtime (min)','Cost','Requested CPUs','Requested memory (GiB)',
+                    'Observed CPU (%)','Observed memory (%)','Peak RSS (GiB)','Read bytes','Write bytes','Task name','Status'];
+      const keys = ['Group','Run ID','Taskhash','Task name short','Executor','Cloudzone',
+                    'Instance type','Realtime_min','Cost','RequestedCPU','RequestedMemory_GiB',
+                    'ObservedCPU_pct','ObservedMemory_pct','PeakRSS_GiB','Readbytes','Writebytes','Task name','Status'];
+      const table = document.getElementById('task-data-table');
+      let html = '<thead><tr>' + cols.map(c => '<th>'+c+'</th>').join('') + '</tr></thead><tbody>';
+      taskTable.slice(0, 500).forEach(r => {
+        html += '<tr>';
+        keys.forEach(k => {
+          let v = r[k];
+          if (k === 'Realtime_min') v = v != null ? Number(v).toFixed(1) : '\u2014';
+          else if (k === 'Cost') v = v != null ? '$' + Number(v).toFixed(6) : '\u2014';
+          else if (k === 'RequestedMemory_GiB' || k === 'PeakRSS_GiB') v = v != null ? Number(v).toFixed(2) : '\u2014';
+          else if (k === 'ObservedCPU_pct' || k === 'ObservedMemory_pct') v = v != null ? Number(v).toFixed(1) : '\u2014';
+          else if (v == null) v = '\u2014';
+          html += '<td>' + v + '</td>';
+        });
+        html += '</tr>';
+      });
+      if (taskTable.length > 500) html += '<tr><td colspan="'+cols.length+'" style="text-align:center;color:#CFD0D1">... and '+(taskTable.length-500)+' more rows</td></tr>';
+      html += '</tbody>';
+      table.innerHTML = html;
+    }, 200);
+  }
+})();
+
+// Side nav: highlight link for section in view
+(function () {
+  const nav = document.getElementById('side-nav');
+  if (!nav) return;
+  const links = [...nav.querySelectorAll('a[href^="#"]')];
+  const sections = links
+    .map((a) => document.getElementById(a.getAttribute('href').slice(1)))
+    .filter(Boolean);
+  if (!sections.length) return;
+
+  function updateActive() {
+    const margin = 100;
+    let current = sections[0];
+    for (const sec of sections) {
+      const top = sec.getBoundingClientRect().top;
+      if (top <= margin) current = sec;
+      else break;
+    }
+    const id = current.id;
+    links.forEach((l) => {
+      l.classList.toggle('active', l.getAttribute('href') === '#' + id);
+    });
+  }
+
+  window.addEventListener('scroll', updateActive, { passive: true });
+  window.addEventListener('resize', updateActive);
+  updateActive();
+})();
+
+// Resize
+window.addEventListener('resize', () => {
+  document.querySelectorAll('.chart').forEach(el => {
+    const inst = echarts.getInstanceByDom(el);
+    if (inst) inst.resize();
+  });
+});
+</script>
+</body>
+</html>

--- a/modules/local/benchmark_report/overrides/functions/SeqeraPlatformRun-class.R
+++ b/modules/local/benchmark_report/overrides/functions/SeqeraPlatformRun-class.R
@@ -1,0 +1,152 @@
+#' SeqeraPlatformRun Class
+#'
+#' @description An S4 class to represent a single pipeline run.
+#'
+#' @slot run_id Character string containing the run ID
+#' @slot path Character string containing the path to run data
+#' @slot pipeline Character string containing the pipeline name
+#' @slot workflow_tasks Data frame containing workflow task information
+#' @slot workflow_metrics Data frame containing workflow metrics
+#' @slot machine_data Data frame containing optional machine-level metrics
+#' @slot run_logs Data frame containing run logs
+#'
+#' @importFrom methods is slot slotNames
+#' @export
+setClass("SeqeraPlatformRun",
+         slots = list(
+           run_id = "character",
+           path = "character",
+           pipeline = "character",
+           workflow_tasks = "data.frame",
+           workflow_metrics = "data.frame",
+           machine_data = "data.frame",
+           run_logs = "data.frame"
+         ))
+
+#' Initialize method for SeqeraPlatformRun
+#' 
+#' @param .Object The SeqeraPlatformRun object to initialize
+#' @param ... Additional arguments to initialize slots
+setMethod("initialize", "SeqeraPlatformRun",
+          function(.Object, ...) {
+            # Call the parent initialize method
+            .Object <- callNextMethod()
+            
+            # Get the list of provided arguments
+            args <- list(...)
+            
+            # Define slot defaults
+            slot_defaults <- list(
+              workflow_tasks = data.frame(),
+              workflow_metrics = data.frame(),
+              machine_data = data.frame(),
+              run_logs = data.frame(),
+              run_id = character(0),
+              path = character(0),
+              pipeline = character(0)
+            )
+            
+            # Assign defaults to slots if not provided
+            for (slot_name in names(slot_defaults)) {
+              if (is.null(args[[slot_name]])) {
+                slot(.Object, slot_name) <- slot_defaults[[slot_name]]
+              }
+            }
+            
+            .Object
+          })
+
+#' Dollar operator for SeqeraPlatformRun objects
+#'
+#' Provides a convenient way to access slots of a SeqeraPlatformRun object using the $ operator.
+#'
+#' @param x A SeqeraPlatformRun object
+#' @param name Character string naming the slot to access
+#'
+#' @return The contents of the requested slot
+#'
+#' @export
+setMethod("$", "SeqeraPlatformRun",
+          function(x, name) {
+            if (name %in% slotNames(x)) {
+              slot(x, name)
+            } else {
+              stop("Invalid slot name: ", name)
+            }
+          })
+#' Internal function to remove prefixes from column names
+#' 
+#' @param names Character vector of column names to format
+#' @return Character vector of formatted column names
+#' @keywords internal
+.removePrefixes <- function(names) {
+  prefixes <- c(
+    "service_info\\.", 
+    "workflow_launch\\.", 
+    "workflow_load\\.", 
+    "workflow_metadata\\.",
+    "workflow\\."
+  )
+  
+  # Combine patterns with | (OR) operator
+  pattern <- paste0("^(", paste(prefixes, collapse="|"), ")")
+  
+  # Remove the prefixes
+  gsub(pattern, "", names)
+}
+
+#' Internal function to format column names in a SeqeraPlatformRun object
+#' 
+#' @param object A SeqeraPlatformRun object
+#' @return The SeqeraPlatformRun object with formatted column names
+#' @keywords internal
+.formatColumnNames <- function(object) {
+  if (nrow(object@run_logs) > 0) {
+    colnames(object@run_logs) <- .removePrefixes(colnames(object@run_logs))
+  }
+  return(object)
+}
+
+
+# Update validity check
+setValidity("SeqeraPlatformRun", function(object) {
+  msgs <- NULL
+  
+  # Check run_id
+  if (length(object@run_id) == 0 || nchar(object@run_id[1]) == 0) {
+    msgs <- c(msgs, "run_id must not be empty")
+  }
+  
+  # Check path
+  if (length(object@path) == 0 || nchar(object@path[1]) == 0) {
+    msgs <- c(msgs, "path must not be empty")
+  }
+  
+  # Check pipeline
+  if (length(object@pipeline) == 0 || nchar(object@pipeline[1]) == 0) {
+    msgs <- c(msgs, "pipeline must not be empty")
+  }
+  
+  # Check data frames
+  df_slots <- c("workflow_tasks", "workflow_metrics", "machine_data", "run_logs")
+  
+  for (slot_name in df_slots) {
+    df <- slot(object, slot_name)
+    if (!is.data.frame(df)) {
+      msgs <- c(msgs, sprintf("%s must be a data frame", slot_name))
+    }
+  }
+  
+  # Check run_logs
+  if (!is.data.frame(object@run_logs)) {
+    msgs <- c(msgs, "run_logs must be a data frame")
+  }
+  
+  if (nrow(object@run_logs) > 0) {
+    if (!"run_id" %in% colnames(object@run_logs)) {
+      msgs <- c(msgs, "run_logs must have a run_id column")
+    }
+  }
+  
+  if (is.null(msgs)) TRUE else msgs
+})

--- a/modules/local/benchmark_report/overrides/functions/SeqeraPlatformRunCollection-methods.R
+++ b/modules/local/benchmark_report/overrides/functions/SeqeraPlatformRunCollection-methods.R
@@ -1,0 +1,351 @@
+# Generic function definitions
+#' Get run IDs from a collection
+#' @param object SeqeraPlatformRunCollection object
+#' @return Character vector of run IDs
+#' @export
+setGeneric("getRunIds", function(object) standardGeneric("getRunIds"))
+
+#' Get pipeline names from a collection
+#' @param object SeqeraPlatformRunCollection object
+#' @return Character vector of pipeline names
+#' @export
+setGeneric("getPipelines", function(object) standardGeneric("getPipelines"))
+
+#' Get group from a collection
+#' @param object SeqeraPlatformRunCollection object
+#' @return Character vector of group labels
+#' @export
+setGeneric("getGroups", function(object) standardGeneric("getGroups"))
+
+#' Get workflow data from a collection
+#' @param object SeqeraPlatformRunCollection object
+#' @param slot_name Character string specifying which slot to get. Must be one of "workflow_metrics", "workflow_tasks", "machine_data", or "run_logs"
+#' @return Combined data frame of the requested workflow data
+#' @export
+setGeneric("getWorkflowData", function(object, slot_name) standardGeneric("getWorkflowData"))
+
+#' Generate a summary message for a SeqeraPlatformRunCollection
+#'
+#' @description Creates a formatted summary message describing the number of pipeline 
+#' executions and groups in the collection.
+#'
+#' @param object A SeqeraPlatformRunCollection object
+#' @return A character string containing the formatted summary message
+#'
+#' @export
+setGeneric("generateReportSummaryMessage", 
+           function(object) standardGeneric("generateReportSummaryMessage"))
+
+#' Create HTML link for run ID
+#' @param run_id Character string of run ID
+#' @param url_table Data frame with run_id and runUrl columns
+#' @return HTML string for link or original run_id if no URL found
+#' @keywords internal
+.create_link <- function(run_id, url_table) {
+  if (is.na(run_id)) return("")
+  url <- url_table$runUrl[url_table$run_id == run_id]
+  if (length(url) == 0) return(run_id)
+  sprintf('<a href="%s" target="_blank">%s</a>', url, run_id)
+}
+
+#' Generate overview table for SeqeraPlatformRunCollection
+#'
+#' @description Creates a reactable table showing pipeline executions by group
+#' with clickable run IDs linking to the Nextflow Tower URLs.
+#'
+#' @param object A SeqeraPlatformRunCollection object
+#' @return A reactable object displaying the overview table
+#'
+#' @importFrom dplyr select filter mutate
+#' @importFrom tidyr pivot_wider
+#' @importFrom reactable reactable colDef
+#' @export
+setGeneric("generateReactOverviewTable", 
+           function(object) standardGeneric("generateReactOverviewTable"))
+
+# Method implementations
+#' Initialize method for SeqeraPlatformRunCollection
+#' @rdname initialize-SeqeraPlatformRunCollection-method
+setMethod("initialize", "SeqeraPlatformRunCollection", function(.Object, ...) {
+  args <- list(...)
+  
+  # First handle the list part
+  if (length(args) > 0 && !is.null(names(args)) && "runs" %in% names(args)) {
+    # If runs is provided as a named argument
+    runs <- args$runs
+  } else {
+    # If runs are provided as unnamed arguments
+    runs <- args[!names(args) %in% c("Class", "group")]
+  }
+  
+  # Convert runs to a list if it isn't already
+  if (!is.list(runs)) {
+    runs <- list(runs)
+  }
+  
+  # Initialize the list part directly
+  for (i in seq_along(runs)) {
+    .Object[[i]] <- runs[[i]]
+  }
+  
+  # Handle group after list initialization
+  if ("group" %in% names(args) && !is.null(args$group)) {
+    .Object@group <- as.character(args$group)
+  } else {
+    # Default to empty strings matching the length of runs
+    .Object@group <- rep("", length(runs))
+  }
+  
+  return(.Object)
+})
+
+# Accessor method implementations
+setMethod("getRunIds", "SeqeraPlatformRunCollection", function(object) {
+  sapply(object, function(x) x@run_id)
+})
+
+setMethod("getPipelines", "SeqeraPlatformRunCollection", function(object) {
+  sapply(object, function(x) x@pipeline)
+})
+
+#' Get workflow data from a collection
+#' @param object SeqeraPlatformRunCollection object
+#' @param slot_name Character string specifying which slot to get. Must be one of "workflow_metrics", "workflow_tasks", "machine_data", or "run_logs"
+#' @return Combined data frame of the requested workflow data
+#' @export
+setMethod("getWorkflowData", "SeqeraPlatformRunCollection", function(object, slot_name) {
+  # Validate slot_name
+  valid_slots <- c("workflow_metrics", "workflow_tasks", "machine_data", "run_logs")
+  if (!slot_name %in% valid_slots) {
+    stop(sprintf("slot_name must be one of: %s", paste(valid_slots, collapse = ", ")))
+  }
+  
+  # Extract data from each run and add run_id and group columns
+  data_list <- lapply(seq_along(object), function(i) {
+    run <- object[[i]]
+    df <- as.data.frame(slot(run, slot_name))  # Ensure it's a data frame
+    
+    if (nrow(df) > 0) {
+      # Add run_id and group columns
+      df$run_id <- run@run_id
+      df$group <- object@group[i]
+      return(df)
+    } else {
+      return(NULL)
+    }
+  })
+  
+  # Remove NULL entries
+  data_list <- data_list[!sapply(data_list, is.null)]
+  
+  # If no data was found, return empty data frame
+  if (length(data_list) == 0) {
+    return(data.frame())
+  }
+  
+  # Check and harmonize column types across all data frames
+  all_cols <- unique(unlist(lapply(data_list, colnames)))
+  
+  # Get column types from first data frame as reference
+  ref_types <- sapply(data_list[[1]], class)
+  
+  # Harmonize column types across all data frames
+  data_list <- lapply(data_list, function(df) {
+    for (col in all_cols) {
+      if (col %in% names(df)) {
+        # If column exists in reference, match its type
+        if (col %in% names(ref_types)) {
+          target_type <- ref_types[col]
+          # Convert column to match reference type
+          tryCatch({
+            if (class(df[[col]]) != target_type) {
+              df[[col]] <- switch(target_type,
+                                "numeric" = as.numeric(df[[col]]),
+                                "integer" = as.integer(df[[col]]),
+                                "character" = as.character(df[[col]]),
+                                "factor" = as.factor(df[[col]]),
+                                df[[col]])  # default: keep original
+            }
+          }, error = function(e) {
+            warning(sprintf("Could not convert column '%s' to type '%s'. Keeping original type.", 
+                          col, target_type))
+          })
+        }
+      } else {
+        # Add missing column with NA of appropriate type
+        df[[col]] <- NA
+        if (col %in% names(ref_types)) {
+          df[[col]] <- switch(ref_types[col],
+                            "numeric" = as.numeric(NA),
+                            "integer" = as.integer(NA),
+                            "character" = as.character(NA),
+                            "factor" = as.factor(NA),
+                            NA)
+        }
+      }
+    }
+    return(df)
+  })
+  
+  # Use bind_rows to combine data frames
+  combined_df <- dplyr::bind_rows(data_list)
+  
+  # Ensure run_id and group are the first columns
+  col_order <- c("run_id", "group", 
+                 setdiff(colnames(combined_df), c("run_id", "group")))
+  combined_df <- combined_df[, col_order]
+  
+  return(combined_df)
+})
+
+setMethod("getGroups", "SeqeraPlatformRunCollection", function(object) {
+  object@group
+})
+
+#' Length method for SeqeraPlatformRunCollection
+#' @param x SeqeraPlatformRunCollection object
+#' @return Number of runs in the collection
+#' @export
+setMethod("length", "SeqeraPlatformRunCollection", function(x) {
+  length(as(x, "list"))
+})
+
+#' Subsetting method for SeqeraPlatformRunCollection
+#' @param x SeqeraPlatformRunCollection object
+#' @param i index
+#' @return SeqeraPlatformRun object or SeqeraPlatformRunCollection for multiple indices
+#' @export
+setMethod("[", "SeqeraPlatformRunCollection", function(x, i) {
+  if (length(i) == 1) {
+    return(as(x, "list")[[i]])
+  }
+  new("SeqeraPlatformRunCollection",
+      runs = as(x, "list")[i])
+}) 
+
+#' Show method for SeqeraPlatformRunCollection objects
+#'
+#' @description Displays a formatted summary of a SeqeraPlatformRunCollection object, including:
+#' \itemize{
+#'   \item Number of runs and unique pipelines
+#'   \item List of runs with their pipeline assignments and groups
+#' }
+#'
+#' @param object A SeqeraPlatformRunCollection object to display
+#' @return Invisibly returns the object while printing its summary to the console
+#' @export
+setMethod("show", "SeqeraPlatformRunCollection", function(object) {
+  # Get run IDs and pipelines using accessor functions
+  run_ids <- getRunIds(object)
+  pipelines <- getPipelines(object)
+  group <- object@group
+  
+  cat("## An object of class SeqeraPlatformRunCollection\n")
+  cat(sprintf("## %d runs across %d unique pipelines\n", 
+              length(run_ids), 
+              length(unique(pipelines))))
+  
+  # Show run IDs with their corresponding pipelines and group
+  cat("## Runs:\n")
+  max_id_length <- max(nchar(run_ids)) + 2
+  max_pipeline_length <- max(nchar(pipelines)) + 2
+  
+  for (i in seq_along(run_ids)) {
+    group_info <- if (length(group) > 0 && !is.na(group[i]) && group[i] != "") 
+      sprintf(" [Group: %s]", group[i]) else ""
+    cat(sprintf("##  %-*s: %s%s\n", 
+                max_id_length, 
+                run_ids[i], 
+                pipelines[i],
+                group_info))
+  }
+  
+  invisible(object)
+})
+
+#' @rdname generateReportSummaryMessage
+setMethod("generateReportSummaryMessage", "SeqeraPlatformRunCollection",
+          function(object) {
+            # Get run logs data
+            run_logs <- getWorkflowData(object, "run_logs")
+            
+            # Calculate unique pipeline executions and groups
+            pipeline_exec <- length(unique(run_logs$run_id))
+            groups <- unique(run_logs$group)
+            
+            # Create summary message
+            summary_message <- paste(
+              "This report summarizes the run, process, task, and, if applicable,",
+              "cost metrics for", pipeline_exec, "pipeline executions, which have",
+              "been split into", length(groups), "groups:",
+              sep=" "
+            )
+            
+            # Format groups string
+            groups_string <- paste(
+              sprintf("**%s**", groups),
+              collapse=",\t"
+            )
+            
+            # Combine messages
+            paste(summary_message, groups_string, sep="\n")
+          })
+
+#' @rdname generateReactOverviewTable
+setMethod("generateReactOverviewTable", "SeqeraPlatformRunCollection",
+          function(object) {
+            # Get run logs data
+            merged_logs <- getWorkflowData(object, "run_logs")
+            run_lookup <- data.frame(
+              pipeline = getPipelines(object),
+              run_id = getRunIds(object),
+              group = getGroups(object),
+              stringsAsFactors = FALSE
+            )
+            
+            # Create URL lookup table
+            url_table <- merged_logs %>% 
+              dplyr::select(dplyr::any_of(c("run_id", "runUrl"))) %>%
+              distinct()
+            if (!"runUrl" %in% names(url_table)) {
+              url_table$runUrl <- run_lookup$run_id
+            }
+            
+            # Create overview dataframe
+            overview_df <- run_lookup %>%
+              dplyr::filter(rowSums(is.na(.)) == 0) %>%
+              distinct() %>%
+              # Extract repo name, keeping nf-core prefix if present
+              dplyr::mutate(pipeline = ifelse(
+                grepl("/nf-core/", pipeline),
+                sub(".*/nf-core/([^/]+)$", "nf-core/\\1", pipeline),
+                sub(".*/([^/]+)$", "\\1", pipeline)
+              )) %>%
+              pivot_wider(names_from = group, values_from = run_id)
+            
+            # Define column definitions for reactable
+            columns_to_link <- setdiff(names(overview_df), "pipeline")
+            
+            column_defs <- lapply(names(overview_df), function(col) {
+              if (col %in% columns_to_link) {
+                colDef(
+                  cell = function(value) {
+                    .create_link(value, url_table)
+                  },
+                  html = TRUE
+                )
+              } else {
+                colDef(name = "Pipeline name")
+              }
+            })
+            names(column_defs) <- names(overview_df)
+            
+            # Create and return reactable
+            reactable(
+              overview_df,
+              fullWidth = FALSE,
+              wrap = TRUE,
+              defaultColDef = colDef(minWidth = 200),
+              columns = column_defs
+            )
+          })

--- a/modules/local/benchmark_report/overrides/functions/createSeqeraPlatformRun-method.R
+++ b/modules/local/benchmark_report/overrides/functions/createSeqeraPlatformRun-method.R
@@ -1,0 +1,152 @@
+#' Create a SeqeraPlatformRun object
+#'
+#' @param input_path Path to either a tar.gz archive or a directory containing JSON files
+#' @param machines_path Optional path to a machine metrics CSV associated with the run
+#'
+#' @return A SeqeraPlatformRun object
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' run <- createSeqeraPlatformRun("path/to/run/folder")
+#' }
+createSeqeraPlatformRun <- function(input_path, machines_path = NULL) {
+  if (!file.exists(input_path)) {
+    stop("Input path does not exist")
+  }
+  if (!is.null(machines_path) && !file.exists(machines_path)) {
+    stop("Machine metrics path does not exist")
+  }
+  
+  # Get the run_id from the input path
+  run_id <- basename(tools::file_path_sans_ext(input_path))
+  if (grepl("\\.tar\\.gz$", input_path)) {
+    run_id <- basename(tools::file_path_sans_ext(tools::file_path_sans_ext(input_path)))
+  }
+  
+  # Handle tar.gz files
+  if (grepl("\\.tar\\.gz$", input_path)) {
+    temp_dir <- tempfile()
+    dir.create(temp_dir)
+    untar(input_path, exdir = temp_dir)
+    working_path <- temp_dir
+  } else {
+    working_path <- input_path
+  }
+  
+  # Function to safely read JSON and convert to data.frame
+  safe_read_json <- function(filepath) {
+    if (file.exists(filepath)) {
+      content <- jsonlite::fromJSON(filepath)
+      
+      # If content is already a data.frame, return it
+      if (is.data.frame(content)) {
+        return(content)
+      }
+      
+      # If content is a list, try to convert it to a data.frame
+      if (is.list(content)) {
+        # If the list has length 1 and contains a data.frame, extract it
+        if (length(content) == 1 && is.data.frame(content[[1]])) {
+          return(content[[1]])
+        }
+        
+        # Try to convert list to data.frame
+        tryCatch({
+          # Handle nested lists by converting them to JSON strings
+          content <- rapply(content, function(x) {
+            if (is.list(x)) jsonlite::toJSON(x) else x
+          }, how = "replace")
+          
+          # Convert to data.frame
+          df <- as.data.frame(t(unlist(content)), stringsAsFactors = FALSE)
+          return(df)
+        }, error = function(e) {
+          # If conversion fails, return empty data.frame with original as json column
+          data.frame(
+            json = jsonlite::toJSON(content, auto_unbox = TRUE),
+            stringsAsFactors = FALSE
+          )
+        })
+      }
+    }
+    data.frame() # Return empty data.frame if file doesn't exist
+  }
+
+  safe_read_machine_csv <- function(filepath) {
+    if (is.null(filepath) || is.na(filepath) || filepath == "" || !file.exists(filepath)) {
+      return(data.frame())
+    }
+
+    tryCatch({
+      df <- data.table::fread(filepath, data.table = FALSE)
+      if (!is.data.frame(df)) {
+        return(data.frame())
+      }
+      df
+    }, error = function(e) {
+      stop(sprintf("Failed to read machine metrics CSV '%s': %s", filepath, e$message))
+    })
+  }
+  
+  # Read all log files
+  log_files <- list(
+    service_info = safe_read_json(file.path(working_path, "service-info.json")),
+    workflow_launch = safe_read_json(file.path(working_path, "workflow-launch.json")),
+    workflow_load = safe_read_json(file.path(working_path, "workflow-load.json")),
+    workflow_metadata = safe_read_json(file.path(working_path, "workflow-metadata.json")),
+    workflow = safe_read_json(file.path(working_path, "workflow.json"))
+  )
+  
+  # Check if all data frames have exactly one row
+  rows <- sapply(log_files, nrow)
+  if (any(rows > 1)) {
+    stop("One or more log files have multiple rows. Expected exactly one row per file:\n",
+         paste(names(rows[rows > 1]), collapse = ", "))
+  }
+  
+  # Handle duplicate column names by adding prefixes
+  all_cols <- unlist(lapply(log_files, colnames))
+  dup_cols <- all_cols[duplicated(all_cols)]
+  if (length(dup_cols) > 0) {
+    for (df_name in names(log_files)) {
+      cols <- colnames(log_files[[df_name]])
+      dup_in_df <- cols[cols %in% dup_cols]
+      if (length(dup_in_df) > 0) {
+        new_names <- paste(df_name, dup_in_df, sep = "_")
+        colnames(log_files[[df_name]])[cols %in% dup_cols] <- new_names
+      }
+    }
+  }
+  
+  # Combine all log files into run_logs
+  run_logs <- do.call(cbind, log_files)
+  run_logs$run_id <- run_id
+  
+  # Extract pipeline information
+  pipeline <- if ("repository" %in% names(log_files$workflow)) {
+    as.character(log_files$workflow$repository[1])
+  } else {
+    ""
+  }
+  
+  # Create the main S4 object
+  run_obj <- methods::new("SeqeraPlatformRun",
+                         run_id = run_id,
+                         path = working_path,
+                         pipeline = pipeline,
+                         workflow_tasks = safe_read_json(file.path(working_path, "workflow-tasks.json")),
+                         workflow_metrics = safe_read_json(file.path(working_path, "workflow-metrics.json")),
+                         machine_data = safe_read_machine_csv(machines_path),
+                         run_logs = run_logs)
+  
+  # Format column names
+  run_obj <- .formatColumnNames(run_obj)
+  
+  # Clean up temporary directory if we created one
+  if (exists("temp_dir")) {
+    unlink(temp_dir, recursive = TRUE)
+  }
+  
+  return(run_obj)
+}

--- a/modules/local/benchmark_report/overrides/functions/createSeqeraPlatformRunCollectionFromSamplesheet-method.R
+++ b/modules/local/benchmark_report/overrides/functions/createSeqeraPlatformRunCollectionFromSamplesheet-method.R
@@ -1,0 +1,48 @@
+#' Create a SeqeraPlatformRunCollection from a samplesheet
+#'
+#' This function reads a samplesheet using fread, creates SeqeraPlatformRun objects
+#' for each row, and combines them into a SeqeraPlatformRunCollection object.
+#'
+#' @param samplesheet_path The file path to the samplesheet CSV file.
+#'
+#' @return A SeqeraPlatformRunCollection object containing the SeqeraPlatformRun objects.
+#'
+#' @details The samplesheet must contain a 'file_path' column. If a 'group' column
+#' is present, its values will be used to assign group to the runs.
+#'
+#' @importFrom data.table fread
+#' @export
+createSeqeraPlatformRunCollectionFromSamplesheet <- function(samplesheet_path) {
+  samplesheet <- fread(samplesheet_path)
+  
+  if (nrow(samplesheet) == 0) {
+    stop("Samplesheet is empty")
+  }
+  
+  if (!"file_path" %in% names(samplesheet)) {
+    stop("Samplesheet must contain a 'file_path' column")
+  }
+  
+  # Extract group if present
+  group <- if ("group" %in% names(samplesheet)) {
+    as.character(samplesheet$group)
+  } else {
+    NULL
+  }
+  
+  # Create SeqeraPlatformRun objects
+  seqera_runs <- lapply(seq_len(nrow(samplesheet)), function(i) {
+    file_path <- samplesheet$file_path[i]
+    machines_path <- if ("machines_path" %in% names(samplesheet)) samplesheet$machines_path[i] else NA_character_
+    if (is.na(machines_path) || machines_path == "") {
+      machines_path <- NULL
+    }
+    createSeqeraPlatformRun(file_path, machines_path = machines_path)
+  })
+  
+  # Create collection using the runs list and group
+  createSeqeraPlatformRunCollection(
+    runs = seqera_runs,
+    group = group
+  )
+}

--- a/modules/local/benchmark_report/overrides/functions/machine_metrics.R
+++ b/modules/local/benchmark_report/overrides/functions/machine_metrics.R
@@ -6,6 +6,27 @@ safe_weighted_mean <- function(values, weights) {
   sum(values[valid] * weights[valid]) / sum(weights[valid])
 }
 
+detect_scheduler_profile <- function(group) {
+  group <- dplyr::coalesce(as.character(group), "")
+  is_batch <- grepl("^Batch", group, ignore.case = TRUE)
+  rightsizing_enabled <- grepl("Predv", group, ignore.case = TRUE)
+
+  provisioning_policy <- dplyr::case_when(
+    grepl("SpotFirst", group, ignore.case = TRUE) ~ "Spot first, then on-demand",
+    grepl("Spot", group, ignore.case = TRUE) ~ "Spot",
+    grepl("OnD", group, ignore.case = TRUE) ~ "On-demand",
+    TRUE ~ ""
+  )
+
+  dplyr::tibble(
+    scheduler_mode = dplyr::if_else(is_batch, "AWS Batch", "Seqera Scheduler"),
+    rightsizing_mode = dplyr::if_else(rightsizing_enabled, "Predv1", "None"),
+    rightsizing_enabled = rightsizing_enabled,
+    packing_enabled = !is_batch,
+    provisioning_policy = provisioning_policy
+  )
+}
+
 positive_gap <- function(upper, lower) {
   dplyr::if_else(
     is.na(upper) | is.na(lower),
@@ -75,6 +96,10 @@ summarise_machine_metrics <- function(machine_data, run_lookup, task_run_metrics
   machine_data <- machine_data %>%
     dplyr::left_join(run_lookup, by = "run_id")
 
+  run_profiles <- run_lookup %>%
+    dplyr::distinct(run_id, pipeline, group)
+  run_profiles <- dplyr::bind_cols(run_profiles, detect_scheduler_profile(run_profiles$group))
+
   if ("instance_id" %in% names(machine_data)) {
     scheduler_summary <- machine_data %>%
       dplyr::mutate(
@@ -124,6 +149,7 @@ summarise_machine_metrics <- function(machine_data, run_lookup, task_run_metrics
   }
 
   scheduler_summary %>%
+    dplyr::left_join(run_profiles %>% dplyr::select(-group), by = c("run_id", "pipeline")) %>%
     dplyr::left_join(
       task_run_metrics %>%
         dplyr::select(run_id, pipeline, realCpuH, realMemGibH, requestedCpuH, requestedMemGibH),
@@ -132,8 +158,16 @@ summarise_machine_metrics <- function(machine_data, run_lookup, task_run_metrics
     dplyr::mutate(
       requestedVmCpuEfficiency = dplyr::if_else(vmCpuH > 0, requestedCpuH / vmCpuH * 100, NA_real_),
       requestedVmMemEfficiency = dplyr::if_else(vmMemGibH > 0, requestedMemGibH / vmMemGibH * 100, NA_real_),
-      schedulerBookedCpuH = compute_scheduler_booked(vmCpuH, schedAllocCpuEfficiency, requestedCpuH),
-      schedulerBookedMemGibH = compute_scheduler_booked(vmMemGibH, schedAllocMemEfficiency, requestedMemGibH),
+      schedulerBookedCpuH = dplyr::if_else(
+        !is.na(rightsizing_enabled) & !rightsizing_enabled & !is.na(requestedCpuH),
+        pmax(requestedCpuH, 0),
+        compute_scheduler_booked(vmCpuH, schedAllocCpuEfficiency, requestedCpuH)
+      ),
+      schedulerBookedMemGibH = dplyr::if_else(
+        !is.na(rightsizing_enabled) & !rightsizing_enabled & !is.na(requestedMemGibH),
+        pmax(requestedMemGibH, 0),
+        compute_scheduler_booked(vmMemGibH, schedAllocMemEfficiency, requestedMemGibH)
+      ),
       schedulerRightsizedCpuH = positive_gap(requestedCpuH, schedulerBookedCpuH),
       schedulerRightsizedMemGibH = positive_gap(requestedMemGibH, schedulerBookedMemGibH),
       schedulerOverbookCpuH = positive_gap(schedulerBookedCpuH, realCpuH),

--- a/modules/local/benchmark_report/overrides/functions/machine_metrics.R
+++ b/modules/local/benchmark_report/overrides/functions/machine_metrics.R
@@ -6,6 +6,25 @@ safe_weighted_mean <- function(values, weights) {
   sum(values[valid] * weights[valid]) / sum(weights[valid])
 }
 
+positive_gap <- function(upper, lower) {
+  dplyr::if_else(
+    is.na(upper) | is.na(lower),
+    NA_real_,
+    pmax(upper - lower, 0)
+  )
+}
+
+compute_scheduler_booked <- function(capacity, efficiency_pct, fallback = NA_real_) {
+  booked_from_capacity <- dplyr::if_else(
+    !is.na(capacity) & !is.na(efficiency_pct),
+    pmin(capacity, pmax(0, capacity * efficiency_pct / 100)),
+    NA_real_
+  )
+
+  fallback <- dplyr::if_else(is.na(fallback), NA_real_, pmax(fallback, 0))
+  dplyr::coalesce(booked_from_capacity, fallback)
+}
+
 parse_machine_percent <- function(x) {
   if (is.numeric(x)) {
     return(as.numeric(x))
@@ -111,6 +130,16 @@ summarise_machine_metrics <- function(machine_data, run_lookup, task_run_metrics
       by = c("run_id", "pipeline")
     ) %>%
     dplyr::mutate(
+      requestedVmCpuEfficiency = dplyr::if_else(vmCpuH > 0, requestedCpuH / vmCpuH * 100, NA_real_),
+      requestedVmMemEfficiency = dplyr::if_else(vmMemGibH > 0, requestedMemGibH / vmMemGibH * 100, NA_real_),
+      schedulerBookedCpuH = compute_scheduler_booked(vmCpuH, schedAllocCpuEfficiency, requestedCpuH),
+      schedulerBookedMemGibH = compute_scheduler_booked(vmMemGibH, schedAllocMemEfficiency, requestedMemGibH),
+      schedulerRightsizedCpuH = positive_gap(requestedCpuH, schedulerBookedCpuH),
+      schedulerRightsizedMemGibH = positive_gap(requestedMemGibH, schedulerBookedMemGibH),
+      schedulerOverbookCpuH = positive_gap(schedulerBookedCpuH, realCpuH),
+      schedulerOverbookMemGibH = positive_gap(schedulerBookedMemGibH, realMemGibH),
+      vmPackingSlackCpuH = positive_gap(vmCpuH, schedulerBookedCpuH),
+      vmPackingSlackMemGibH = positive_gap(vmMemGibH, schedulerBookedMemGibH),
       realVmCpuEfficiency = dplyr::if_else(vmCpuH > 0, realCpuH / vmCpuH * 100, NA_real_),
       realVmMemEfficiency = dplyr::if_else(vmMemGibH > 0, realMemGibH / vmMemGibH * 100, NA_real_)
     )

--- a/modules/local/benchmark_report/overrides/functions/machine_metrics.R
+++ b/modules/local/benchmark_report/overrides/functions/machine_metrics.R
@@ -100,8 +100,17 @@ summarise_machine_metrics <- function(machine_data, run_lookup, task_run_metrics
     dplyr::distinct(run_id, pipeline, group)
   run_profiles <- dplyr::bind_cols(run_profiles, detect_scheduler_profile(run_profiles$group))
 
-  if ("instance_id" %in% names(machine_data)) {
+  scheduler_summary <- data.frame()
+  batch_summary <- data.frame()
+
+  has_scheduler_rows <- "instance_id" %in% names(machine_data) &&
+    any(!is.na(machine_data$instance_id) & machine_data$instance_id != "")
+  has_batch_rows <- "ecs_instance_id" %in% names(machine_data) &&
+    any(!is.na(machine_data$ecs_instance_id) & machine_data$ecs_instance_id != "")
+
+  if (has_scheduler_rows) {
     scheduler_summary <- machine_data %>%
+      dplyr::filter(!is.na(instance_id), instance_id != "") %>%
       dplyr::mutate(
         machine_id = instance_id,
         vcpus = as.numeric(vcpus),
@@ -121,14 +130,23 @@ summarise_machine_metrics <- function(machine_data, run_lookup, task_run_metrics
         schedAllocMemEfficiency = safe_weighted_mean(avg_memory_utilization, memory_gib * machine_hours),
         .groups = "drop"
       )
-  } else if ("ecs_instance_id" %in% names(machine_data)) {
-    scheduler_summary <- machine_data %>%
+  }
+
+  if (has_batch_rows) {
+    batch_summary <- machine_data %>%
+      dplyr::filter(!is.na(ecs_instance_id), ecs_instance_id != "") %>%
       dplyr::mutate(
         machine_id = ecs_instance_id,
-        total_vcpu_hours = as.numeric(total_vcpu_hours),
-        total_memory_gib_hours = as.numeric(total_memory_gib_hours),
-        requested_vcpu_hours = dplyr::coalesce(as.numeric(total_requested_vcpu_hours), as.numeric(requested_vcpu_hours)),
-        requested_memory_gib_hours = dplyr::coalesce(as.numeric(total_requested_memory_gib_hours), as.numeric(requested_memory_gib_hours))
+        total_vcpu_hours = suppressWarnings(as.numeric(total_vcpu_hours)),
+        total_memory_gib_hours = suppressWarnings(as.numeric(total_memory_gib_hours)),
+        requested_vcpu_hours = dplyr::coalesce(
+          suppressWarnings(as.numeric(total_requested_vcpu_hours)),
+          suppressWarnings(as.numeric(requested_vcpu_hours))
+        ),
+        requested_memory_gib_hours = dplyr::coalesce(
+          suppressWarnings(as.numeric(total_requested_memory_gib_hours)),
+          suppressWarnings(as.numeric(requested_memory_gib_hours))
+        )
       ) %>%
       dplyr::group_by(run_id, pipeline) %>%
       dplyr::summarise(
@@ -143,7 +161,11 @@ summarise_machine_metrics <- function(machine_data, run_lookup, task_run_metrics
         schedAllocCpuEfficiency = dplyr::if_else(vmCpuH > 0, requestedVmCpuH / vmCpuH * 100, NA_real_),
         schedAllocMemEfficiency = dplyr::if_else(vmMemGibH > 0, requestedVmMemGibH / vmMemGibH * 100, NA_real_)
       )
-  } else {
+  }
+
+  scheduler_summary <- dplyr::bind_rows(scheduler_summary, batch_summary)
+
+  if (nrow(scheduler_summary) == 0) {
     warning("Machine metrics CSV detected, but its schema is not recognized. Skipping VM metrics.")
     return(data.frame())
   }

--- a/modules/local/benchmark_report/overrides/functions/machine_metrics.R
+++ b/modules/local/benchmark_report/overrides/functions/machine_metrics.R
@@ -1,0 +1,117 @@
+safe_weighted_mean <- function(values, weights) {
+  valid <- !is.na(values) & !is.na(weights) & weights > 0
+  if (!any(valid)) {
+    return(NA_real_)
+  }
+  sum(values[valid] * weights[valid]) / sum(weights[valid])
+}
+
+parse_machine_percent <- function(x) {
+  if (is.numeric(x)) {
+    return(as.numeric(x))
+  }
+  as.numeric(gsub("%", "", x))
+}
+
+parse_machine_memory_gib <- function(x) {
+  if (is.numeric(x)) {
+    return(as.numeric(x))
+  }
+  as.numeric(stringr::str_extract(x, "[0-9.]+"))
+}
+
+compute_task_run_metrics <- function(task_data) {
+  if (nrow(task_data) == 0) {
+    return(data.frame())
+  }
+
+  task_data %>%
+    dplyr::mutate(
+      cpus = as.numeric(cpus),
+      pcpu = as.numeric(pcpu),
+      realtime_hours = as.numeric(realtime) / 1000 / 3600,
+      requested_memory_gib_raw = dplyr::coalesce(requested_memory_gib_raw, 0),
+      rss_gib_raw = dplyr::coalesce(rss_gib_raw, 0)
+    ) %>%
+    dplyr::group_by(run_id, pipeline) %>%
+    dplyr::summarise(
+      task_runtime_ms = sum(runtime_mins, na.rm = TRUE) * 60 * 1000,
+      requestedCpuH = sum(cpus * realtime_hours, na.rm = TRUE),
+      requestedMemGibH = sum(requested_memory_gib_raw * realtime_hours, na.rm = TRUE),
+      realCpuH = sum((pcpu / 100) * realtime_hours, na.rm = TRUE),
+      realMemGibH = sum(rss_gib_raw * realtime_hours, na.rm = TRUE),
+      .groups = "drop"
+    ) %>%
+    dplyr::mutate(
+      cpuEfficiency_calc = dplyr::if_else(requestedCpuH > 0, realCpuH / requestedCpuH * 100, NA_real_),
+      memoryEfficiency_calc = dplyr::if_else(requestedMemGibH > 0, realMemGibH / requestedMemGibH * 100, NA_real_)
+    )
+}
+
+summarise_machine_metrics <- function(machine_data, run_lookup, task_run_metrics) {
+  if (nrow(machine_data) == 0) {
+    return(data.frame())
+  }
+
+  machine_data <- machine_data %>%
+    dplyr::left_join(run_lookup, by = "run_id")
+
+  if ("instance_id" %in% names(machine_data)) {
+    scheduler_summary <- machine_data %>%
+      dplyr::mutate(
+        machine_id = instance_id,
+        vcpus = as.numeric(vcpus),
+        memory_gib = parse_machine_memory_gib(memory),
+        avg_cpu_utilization = parse_machine_percent(avg_cpu_utilization),
+        avg_memory_utilization = parse_machine_percent(avg_memory_utilization),
+        start_time = as.POSIXct(start_time, tz = "UTC"),
+        stop_time = as.POSIXct(stop_time, tz = "UTC"),
+        machine_hours = pmax(as.numeric(difftime(stop_time, start_time, units = "hours")), 0)
+      ) %>%
+      dplyr::group_by(run_id, pipeline) %>%
+      dplyr::summarise(
+        nMachines = dplyr::n_distinct(machine_id),
+        vmCpuH = sum(vcpus * machine_hours, na.rm = TRUE),
+        vmMemGibH = sum(memory_gib * machine_hours, na.rm = TRUE),
+        schedAllocCpuEfficiency = safe_weighted_mean(avg_cpu_utilization, vcpus * machine_hours),
+        schedAllocMemEfficiency = safe_weighted_mean(avg_memory_utilization, memory_gib * machine_hours),
+        .groups = "drop"
+      )
+  } else if ("ecs_instance_id" %in% names(machine_data)) {
+    scheduler_summary <- machine_data %>%
+      dplyr::mutate(
+        machine_id = ecs_instance_id,
+        total_vcpu_hours = as.numeric(total_vcpu_hours),
+        total_memory_gib_hours = as.numeric(total_memory_gib_hours),
+        requested_vcpu_hours = dplyr::coalesce(as.numeric(total_requested_vcpu_hours), as.numeric(requested_vcpu_hours)),
+        requested_memory_gib_hours = dplyr::coalesce(as.numeric(total_requested_memory_gib_hours), as.numeric(requested_memory_gib_hours))
+      ) %>%
+      dplyr::group_by(run_id, pipeline) %>%
+      dplyr::summarise(
+        nMachines = dplyr::n_distinct(machine_id),
+        vmCpuH = sum(total_vcpu_hours, na.rm = TRUE),
+        vmMemGibH = sum(total_memory_gib_hours, na.rm = TRUE),
+        requestedVmCpuH = sum(requested_vcpu_hours, na.rm = TRUE),
+        requestedVmMemGibH = sum(requested_memory_gib_hours, na.rm = TRUE),
+        .groups = "drop"
+      ) %>%
+      dplyr::mutate(
+        schedAllocCpuEfficiency = dplyr::if_else(vmCpuH > 0, requestedVmCpuH / vmCpuH * 100, NA_real_),
+        schedAllocMemEfficiency = dplyr::if_else(vmMemGibH > 0, requestedVmMemGibH / vmMemGibH * 100, NA_real_)
+      )
+  } else {
+    warning("Machine metrics CSV detected, but its schema is not recognized. Skipping VM metrics.")
+    return(data.frame())
+  }
+
+  scheduler_summary %>%
+    dplyr::left_join(
+      task_run_metrics %>%
+        dplyr::select(run_id, pipeline, realCpuH, realMemGibH, requestedCpuH, requestedMemGibH),
+      by = c("run_id", "pipeline")
+    ) %>%
+    dplyr::mutate(
+      realVmCpuEfficiency = dplyr::if_else(vmCpuH > 0, realCpuH / vmCpuH * 100, NA_real_),
+      realVmMemEfficiency = dplyr::if_else(vmMemGibH > 0, realMemGibH / vmMemGibH * 100, NA_real_)
+    )
+}

--- a/modules/local/benchmark_report/overrides/quarto_content/ingest_data.qmd
+++ b/modules/local/benchmark_report/overrides/quarto_content/ingest_data.qmd
@@ -1,0 +1,354 @@
+
+```{r read-platform-logs}
+#| echo: false
+#| include: false
+#| results: hide
+  
+seqera_platform_logs <- createSeqeraPlatformRunCollectionFromSamplesheet(params$log_csv)
+```
+
+
+```{r merge-platform-logs}
+#| echo: false
+#| include: false
+#| results: hide
+
+#### Merge information across logs containing run level information
+merged_logs <- getWorkflowData(seqera_platform_logs,"run_logs")
+
+#### Temporary hack for column names in newly joined logs
+## Get rid of the following items in front of columns names: service_info., workflow_launch., workflow_load., workflow_metadata. and workflow
+# Function to remove prefixes
+remove_prefixes <- function(names) {
+  prefixes <- c(
+    "service_info\\.", 
+    "workflow_launch\\.", 
+    "workflow_load\\.", 
+    "workflow_metadata\\.",
+    "workflow\\."
+  )
+  
+  # Combine patterns with | (OR) operator
+  pattern <- paste0("^(", paste(prefixes, collapse="|"), ")")
+  
+  # Remove the prefixes
+  gsub(pattern, "", names)
+}
+
+# Apply to your dataframe
+colnames(merged_logs) <- remove_prefixes(colnames(merged_logs))
+####
+
+## Add pipeline name from  Repository URL, take the element after the last /
+merged_logs$pipeline <- str_extract(merged_logs$repository, "[^/]+$")
+
+# Use tidy to convert multiple columns to numeric in merged_logs dataframe
+merged_logs <- merged_logs %>%
+  mutate(
+    cost = if ("cost" %in% colnames(.)) as.numeric(cost) else NA_real_,
+    cpuTime = if ("cpuTime" %in% colnames(.)) as.numeric(cpuTime) else NA_real_,
+    duration = if ("duration" %in% colnames(.)) as.numeric(duration) else NA_real_,
+    readBytes = if ("readBytes" %in% colnames(.)) as.numeric(readBytes) else NA_real_,
+    writeBytes = if ("writeBytes" %in% colnames(.)) as.numeric(writeBytes) else NA_real_,
+    cpuEfficiency = if ("cpuEfficiency" %in% colnames(.)) as.numeric(cpuEfficiency) else NA_real_,
+    memoryEfficiency = if ("memoryEfficiency" %in% colnames(.)) as.numeric(memoryEfficiency) else NA_real_,
+    succeeded = dplyr::coalesce(
+      if ("succeeded" %in% colnames(.)) as.numeric(succeeded) else NA_real_,
+      if ("stats.succeedCount" %in% colnames(.)) as.numeric(`stats.succeedCount`) else NA_real_
+    ),
+    failed = dplyr::coalesce(
+      if ("failed" %in% colnames(.)) as.numeric(failed) else NA_real_,
+      if ("stats.failedCount" %in% colnames(.)) as.numeric(`stats.failedCount`) else NA_real_
+    ),
+    cached = dplyr::coalesce(
+      if ("cached" %in% colnames(.)) as.numeric(cached) else NA_real_,
+      if ("stats.cachedCount" %in% colnames(.)) as.numeric(`stats.cachedCount`) else NA_real_
+    )
+  )
+
+merged_logs <- merged_logs %>%
+  mutate("cost" = round(cost,2),
+         "cpuTime" = round(cpuTime / 60 / 60 / 1000,1),
+         "readBytes" = round(readBytes / (1024*1024*1024),2),
+         "writeBytes" = round(writeBytes / (1024*1024*1024),2),
+         "cpuEfficiency" = round(cpuEfficiency,2),
+         "memoryEfficiency" = round(memoryEfficiency,2),
+         "total_tasks" = succeeded + failed + cached
+         ) %>%
+  arrange(pipeline)
+
+## Set the factor order level of pipelines based on min walltime per group
+pipeline_order <- merged_logs %>%
+  ungroup() %>%
+  group_by(pipeline) %>%
+  summarise(min_walltime = min(duration)) %>%
+  arrange(min_walltime) %>%
+  pull(pipeline)
+
+merged_logs$pipeline <- factor(merged_logs$pipeline,
+                               levels = rev(pipeline_order))
+
+## If Seqera is one of the group labels, make Seqera be the first group / baseline
+if("Seqera" %in% unique(seqera_platform_logs@group)){ ## If doing quicklaunch
+    other_groups <- unique(merged_logs$group)[!unique(merged_logs$group) %in% "Seqera"]
+    merged_logs$group <- factor(merged_logs$group, levels = c("Seqera",other_groups))
+}else{
+  merged_logs$group <- factor(merged_logs$group,levels = unique(seqera_platform_logs@group))
+}
+
+groups_color_palette <- groups_color_palette[1:length(unique(merged_logs$group))]
+names(groups_color_palette) <- unique(merged_logs$group)
+
+## Determine how many maximum runs were done per pipeline (for example maybe one pipeline was run 3 times)
+n_runs <- merged_logs %>%
+  group_by(group,pipeline) %>%
+  summarise(n = n())
+n_runs_max <- max(n_runs$n)
+
+## Determine how many groups there are
+n_groups <- length(unique(merged_logs$group))
+
+## Determine what kind of benchmarking scenario we are analysing
+## 1) Scenario 1 : 2 Groups - 1 run per pipeline (id : 2groups_1run)
+## 2) Scenario 2 : 2 Groups - multiple runs per pipeline (id : 2groups_Nrun)
+## 3) Scenario 3 : N Groups (>2) - 1 run per pipeline (id : Ngroups_1run)
+## 4) Scenario 4 : N Groups (>2) - multiple runs per pipeline (id : Ngroups_Nrun)
+benchmark_scenario <- "NA"
+if (length(unique(merged_logs$group)) == 2 & n_runs_max == 1) {
+  benchmark_scenario <- "2groups_1run"
+}else if(length(unique(merged_logs$group)) == 2 & n_runs_max > 1){
+  benchmark_scenario <- "2groups_Nrun"
+}else if(length(unique(merged_logs$group)) > 2 & n_runs_max == 1){
+  benchmark_scenario <- "Ngroups_1run"
+}else if(length(unique(merged_logs$group)) > 2 & n_runs_max > 1){
+  benchmark_scenario <- "Ngroups_Nrun"
+}
+
+#### Task logs
+## Process logs containing task level information
+task_data <- getWorkflowData(seqera_platform_logs,"workflow_tasks")
+
+## Add pipeline name to task_data
+run_id_pipeline <- merged_logs %>% select(run_id,pipeline)
+task_data <- left_join(task_data,run_id_pipeline,by = "run_id")
+
+task_data <- task_data %>%
+    mutate(submit = as.POSIXct(submit, format = "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC"),
+           start = as.POSIXct(start, format = "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC"),
+           complete = as.POSIXct(complete, format = "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC")
+           ) %>%
+  mutate(runtime_seconds = as.numeric(difftime(as.POSIXct(complete), as.POSIXct(start), units = "secs")),
+         runtime_mins = as.numeric(difftime(as.POSIXct(complete), as.POSIXct(start), units = "mins")),
+         runtime_hours = as.numeric(difftime(as.POSIXct(complete), as.POSIXct(start), units = "hours")),
+         waittime_mins = as.numeric(difftime(as.POSIXct(start), as.POSIXct(submit), units = "mins")),
+         realtime_mins = (as.numeric(realtime) / 1000 / 60 ),
+         duration_mins = (as.numeric(duration) / 1000 / 60 ),
+         staging_time_mins = runtime_mins - realtime_mins,
+         staging_time_mins = if_else(staging_time_mins < 0, 0, staging_time_mins) ## Sometimes staging time calculation can result in negative staging time, instead set it to 0
+         ) %>%
+  mutate(process_short = paste(str_extract(process, "[^:]+$"),sep=" - "),
+        # Check if name_short has : in the name, if not, keep as is, if it does, do name_short = paste(str_extract(process, "[^:]+$")," (",tag,")",sep="")
+        name_short = ifelse(grepl(":",process),paste(str_extract(process, "[^:]+$")," (",tag,")",sep=""),process)
+        ) %>%
+  mutate(requested_memory_gib_raw = memory / (1024*1024*1024),
+         rss_gib_raw = rss / (1024*1024*1024),
+         "memory" = round(requested_memory_gib_raw,2),
+         "rss" = round(rss_gib_raw,2),
+          runtime = sprintf("%02d:%02d:%02d", floor(runtime_mins / 60), floor(runtime_mins %% 60), round((runtime_mins %% 1) * 60))
+         ) %>%
+  mutate(waittime = sprintf("%02d:%02d:%02d", floor(waittime_mins / 60), floor(waittime_mins %% 60), round((waittime_mins %% 1) * 60)),
+         staging_time = sprintf("%02d:%02d:%02d", floor(staging_time_mins / 60), floor(staging_time_mins %% 60), round((staging_time_mins %% 1) * 60)),
+         real_time = sprintf("%02d:%02d:%02d", floor(realtime_mins / 60), floor(realtime_mins %% 60), round((realtime_mins %% 1) * 60))
+         )
+
+## TODO: Establish task group ordering via group inside functions in the future
+# # Also for task level data, ensure that Seqera label is first / baseline if present
+# if("Seqera" %in% unique(seqera_platform_logs@group)){ ## If doing quicklaunch
+#     other_groups <- unique(seqera_platform_logs@group)[!unique(seqera_platform_logs@group) %in% "Seqera"]
+#     task_data$group <- factor(task_data$group,levels = c("Seqera",other_groups))
+# }else{
+#   ## Otherwise, take the order of unique labels as provided in the samplesheet input
+#   task_data$group <- factor(task_data$group, levels = unique(log_files$group))
+# }
+
+## If user wants to filter out failed tasks for calculations, remove them
+if(params$remove_failed_tasks != "NA"){
+  task_data <- task_data %>%
+    subset(status == "COMPLETED")
+}
+
+# Some sanity checks 
+first_task <- task_data %>%
+  # Get the row with the earlierst submit field per run_id in task_data
+  group_by(run_id) %>%
+  filter(submit == min(submit)) %>%
+  ungroup()
+
+#####
+## Recompute task-derived run metrics directly from the task logs so the report is self-consistent.
+task_run_metrics <- compute_task_run_metrics(task_data)
+merged_logs <- left_join(merged_logs, task_run_metrics, by = c("run_id", "pipeline"))
+
+## Prefer task-derived metrics over run-level summary values when they are available.
+merged_logs <- merged_logs %>%
+  mutate(
+    cpuTime = dplyr::coalesce(round(requestedCpuH, 1), cpuTime),
+    cpuEfficiency = dplyr::coalesce(round(cpuEfficiency_calc, 2), cpuEfficiency),
+    memoryEfficiency = dplyr::coalesce(round(memoryEfficiency_calc, 2), memoryEfficiency),
+    task_runtime_ms = dplyr::coalesce(task_runtime_ms, duration)
+  ) %>%
+  select(-cpuEfficiency_calc, -memoryEfficiency_calc)
+
+## Aggregate optional machine-level metrics.
+machine_data <- getWorkflowData(seqera_platform_logs, "machine_data")
+machine_run_metrics <- data.frame()
+if (nrow(machine_data) > 0) {
+  machine_run_metrics <- summarise_machine_metrics(machine_data, run_id_pipeline, task_run_metrics)
+  merged_logs <- left_join(merged_logs, machine_run_metrics, by = c("run_id", "pipeline"))
+}
+
+##### Add total workdir size to merged_logs if available
+# Check if workdirsizes are provided in the task log
+# Check if workdirSize is in colnames of task_data
+if("workdirSize" %in% colnames(task_data)){
+  aws_s3_price_perGB <- 0.023
+  fsx_price_perGB    <- 0.154
+  
+  workdirSizes <- task_data %>%
+    # Check if fsx is in the string in the column workdir and create a new column storage_type
+    mutate(storage_type = if_else(str_detect(workdir, "fsx"),"FSx","S3")) %>%
+    group_by(run_id,pipeline,storage_type) %>%
+    summarise(pipeline_workdirSize = sum(workdirSize)) %>%
+    #Convert pipeline_workdirSize from bytes to GB
+    mutate(pipeline_workdirSize_GB = pipeline_workdirSize / (1024*1024*1024)) %>%
+    mutate(pipeline_workdirSize_price = if_else(storage_type == "FSx"
+                                                  ,pipeline_workdirSize_GB * fsx_price_perGB,
+                                                  pipeline_workdirSize_GB * aws_s3_price_perGB)) %>%
+    ungroup()
+
+merged_logs <- left_join(merged_logs,workdirSizes,by=c("run_id","pipeline"))
+}
+```
+
+
+```{r generate-cost-table}
+#| echo: true
+#| include: false
+#| results: hide
+
+## This code block will read in the aws data export if provided and the estimated cost from Seqera Platform
+## Both cost tables will be formatted the same way, so that the accurate cost report can simple be used in place of the estimated cost report
+
+accurate_task_costs <- data.frame()
+## Check whether accurate cost reports are available
+if(params$aws_cost != "NA") {
+  ## Select only relevant columns
+  core_aws_cur_cols <- c("identity_line_item_id",
+                     "line_item_usage_type",
+                     "split_line_item_split_cost",
+                     "split_line_item_unused_cost",
+                     "line_item_blended_cost",
+                     "resource_tags")
+  
+  ## Read in aws Cur parquet file
+  aws_cost_table <- read_parquet(params$aws_cost)
+  ## Determin whether cur report is 1.0 or 2.0 formatting
+  if ("resource_tags" %in% names(aws_cost_table)) {
+    message("AWS CUR 2.0 format detected. Converting resource tags to individual columns...")
+    aws_cost_table <- reformat_cur2_0(aws_cost_table, 
+                                      run_ids = unique(merged_logs$run_id), 
+                                      run_id_col = "resource_tags_user_unique_run_id")
+    message("CUR 2.0 conversion complete.")
+    ## Remove resource tags as column from core_aws_cur_cols
+    core_aws_cur_cols <- core_aws_cur_cols[!core_aws_cur_cols %in% "resource_tags"]
+  }else{
+    message("AWS CUR 1.0 format detected. Proceeding in rendering report.")
+  }
+
+  ## Check if required resource tag columns exist in the AWS cost table
+  required_tags <- c("resource_tags_user_unique_run_id", 
+                     "resource_tags_user_pipeline_process", 
+                     "resource_tags_user_task_hash")
+  
+  missing_tags <- required_tags[!required_tags %in% names(aws_cost_table)]
+  
+  if(length(missing_tags) > 0) {
+    message("The following resource tag columns are missing from the AWS cost report: ", 
+            paste(missing_tags, collapse=", "))
+  }
+  
+  core_aws_cur_cols <- c(core_aws_cur_cols,required_tags)
+  
+  accurate_task_costs <- aws_cost_table %>%
+    select(all_of(core_aws_cur_cols)) %>%
+    mutate("cost"     = split_line_item_split_cost + split_line_item_unused_cost,
+           "used_cost"= split_line_item_split_cost,
+           "unused_cost" = split_line_item_unused_cost) %>%
+    mutate("run_id"    = resource_tags_user_unique_run_id,
+           "process"  = resource_tags_user_pipeline_process,
+           "hash" = resource_tags_user_task_hash)
+  # Take only the first 8 characters of the hash
+  accurate_task_costs$hash <- substr(accurate_task_costs$hash,1,8)
+  
+  ## Add group to accurate_task_costs
+  # Check if all run_ids from merged_logs are present in accurate_task_costs
+  missing_run_ids <- setdiff(unique(merged_logs$run_id), unique(accurate_task_costs$run_id))
+  if (length(missing_run_ids) > 0) {
+    stop(paste0("Error: The following runs were not found in AWS cost data (make sure they were tagged correctly and enough time has passed for the data to be available): ", 
+                paste(missing_run_ids, collapse=", "), 
+                ". Please check your AWS cost data or run_id values."))
+  }
+  
+  # If all run_ids are present, proceed with the join
+  accurate_task_costs <- accurate_task_costs %>%
+    left_join(merged_logs %>% select(run_id, group, pipeline), by = "run_id")
+  
+  ## Sum up costs for cpu and memory
+  accurate_task_costs <- accurate_task_costs %>%
+    group_by(run_id,pipeline,group,process,hash) %>%
+    summarise(cost = sum(cost),
+              used_cost = sum(used_cost),
+              unused_cost = sum(unused_cost)) %>%
+    ungroup()
+}
+      
+
+## If we don't have a accurate cost report, we will use the estimated cost from platform for all cost reporting
+if(length(unique(merged_logs$executors)) > 1){ ## If we are comparing runs from different executors (i.e. slurm vs )
+  estim_task_costs <- task_data %>%
+    select(run_id,pipeline,group,process,cost,hash)
+  estim_task_costs$hash <- gsub("/","",estim_task_costs$hash)
+}else if(length(unique(merged_logs$executors)) == 1){ ## We are comparing runs from the same executor
+  if(unique(merged_logs$executors) %in% c("azure-batch","azurebatch")){
+      estim_task_costs <- task_data %>%
+        select(run_id,pipeline,group,process,hash)
+      estim_task_costs$hash <- gsub("/","",estim_task_costs$hash)
+  }else if (unique(merged_logs$executors) == "google-batch"){
+    estim_task_costs <- task_data %>%
+      select(run_id,pipeline,group,process,hash)
+    estim_task_costs$hash <- gsub("/","",estim_task_costs$hash)
+  }else{
+    estim_task_costs <- task_data %>%
+      select(run_id,pipeline,group,process,cost,hash)
+  estim_task_costs$hash <- gsub("/","",estim_task_costs$hash)
+  }
+}
+
+## Check which scenario the user wants to view
+## 1) Use estimated costs
+if(grepl("cost",profile) & nrow(accurate_task_costs) == 0){
+  cost_table <- estim_task_costs
+}else if(grepl("cost",profile) & nrow(accurate_task_costs) > 1){
+## 2) Use accurate costs
+  cost_table <- accurate_task_costs
+}
+
+## Filter for completed task if param is set
+if(grepl("cost",profile) & params$remove_failed_tasks != "NA"){
+  task_data_sub_cost <- task_data %>% select("run_id","hash","status")
+  task_data_sub_cost$hash <- gsub("/","",task_data_sub_cost$hash)
+  cost_table <- left_join(cost_table,task_data_sub_cost,by=c("run_id","hash"))
+  cost_table <- cost_table %>%
+    subset(status == "COMPLETED")
+}
+```

--- a/modules/local/benchmark_report/overrides/quarto_content/process_overview.qmd
+++ b/modules/local/benchmark_report/overrides/quarto_content/process_overview.qmd
@@ -1,0 +1,226 @@
+# Process overview
+
+::: {.callout-note .benchmark_callouts title="Summary"}
+This section provides a comparison of the process-level metrics for each pipeline across the groups: `r groups_string`. 
+:::
+
+The plots in this section show the task-duration distribution per process in each Nextflow pipeline. Dots represent mean values per process across all tasks. Error bars indicate mean +- 1 standard deviation. A single point indicates that a single task was executed for the process.
+
+- **Task duration** = Staging time + real time
+
+::: {.callout-tip .benchmark_callouts title="Plot interaction" collapse="true"}
+ - Hover over points to see the process name and average run time / total process cost.
+ - Zoom in to focus on specific processes.
+ - Click on the legend to hide or show groups.
+:::
+
+```{r, results='asis'}
+#| label: process-level-plots
+#| fig-width: 12
+#| fig-height: 12
+
+#### Process cost if cost profile is activated
+for(pipe in unique(task_data$pipeline)){
+  cat(paste0("### ",pipe, " \n"))
+  
+  pipe_parsed <- gsub("/","_",pipe)
+  pipe_crosstalk <- paste(pipe,"_process-cost")
+  
+  if(grepl("cost",profile)){
+    
+    cost_table_pipe <- subset(cost_table,pipeline == pipe)
+    
+    ## Calculate per process total cost and standard deviation per process
+    cost_per_process <- cost_table_pipe %>%
+      group_by(process, group, run_id) %>%
+      summarise(
+        process_cost = sum(cost),
+        average_cost = round(mean(cost),4),
+        n_tasks = n()
+      ) %>%
+      ungroup()
+    
+      ## Calculate the difference in cost per process between groups
+      cost_per_process$group <- factor(cost_per_process$group,
+                                       levels = unique(seqera_platform_logs@group))
+      
+      cost_diff <- cost_per_process %>%
+        select(-c(run_id,average_cost,n_tasks)) %>%
+        group_by(process) %>%
+        summarise(sd_group_cost = sd(process_cost)) %>%
+        ungroup() %>%
+        arrange(desc(sd_group_cost))
+        
+      ## Sort processes based on cost difference
+      cost_per_process$process <- factor(cost_per_process$process,
+                                         levels = unique(cost_diff$process))
+      
+      shared_data_cost_diff <- SharedData$new(cost_per_process, key = ~process, group = pipe_crosstalk)
+      
+      cost_diff_lolliplot <- ggplot(shared_data_cost_diff,aes(x = process, y = process_cost,
+                                             text = paste("Process name: ",process,"\n",
+                                                          "Cost difference: ",round(process_cost,4),"$ \n",
+                                                          sep=""))) +
+        # geom_segment(aes(xend = process, yend = 0),color = "black", linewidth = 0.5) +
+        # geom_point(aes(color = group_color), size = 2.5) +
+        geom_bar(stat = "identity", position = "dodge", 
+                 aes(fill = group)) +
+        seqera_light_theme() +
+        scale_fill_manual(values = groups_color_palette,
+                           labels = gsub("_"," ",names(groups_color_palette))) +
+        labs(x = "Processes",
+             y = "Total Process cost ($)",
+             title = "Process cost per group",
+             color = "group") +
+        theme(axis.text.x = element_blank(),
+              axis.ticks.x = element_blank(),
+              axis.line.x = element_blank(), 
+              legend.title = element_text(face = "bold"),
+              # Hide facet box and labels
+              strip.background = element_blank(),
+              strip.text = element_blank(),
+              plot.title = element_text(size = plot_title_size)
+        )
+      
+        print(htmltools::tagList(
+      ggplotly(cost_diff_lolliplot, tooltip = "text") %>%
+        set_ggplotly_font() %>%
+        highlight(on = "plotly_click", off = "plotly_doubleclick", opacityDim = 0.05)
+      )
+    )
+    
+    ##### Cost Table
+    ## For each run_id, calculate how much cost each process contributes to the total cost
+    process_contribution <- cost_per_process %>%
+      group_by(run_id) %>%
+      mutate(total_cost = sum(process_cost)) %>%
+      ungroup() %>%
+      mutate(process_cost_perc = round(process_cost / total_cost * 100,2)) %>%
+      select(group,run_id,process,process_cost,process_cost_perc,average_cost,n_tasks) %>%
+      mutate("process_cost" = round(process_cost,4)) %>%
+      ungroup()
+    process_contribution$group <- factor(process_contribution$group)
+    
+      font.size <- "12"
+       row_alpha_value <- 0.15
+       point_alpha <- 1
+       point_size <- 2
+    
+      shared_data_process_contribution <- SharedData$new(process_contribution, key = ~process, group = pipe_crosstalk)
+      rgba_colors <- sapply(groups_color_palette, hex_to_rgba, alpha = row_alpha_value)[1:length(unique(process_contribution$group))]
+      process_cost_table <- div(class = "scrollable-table",
+                             datatable(shared_data_process_contribution,
+                                   class = 'nowrap',
+                                   escape = FALSE,
+                                   colnames = c("Group" = "group",
+                                                "Run ID" = "run_id", 
+                                                "Process" = "process",
+                                                "Process Cost ($)" = "process_cost",
+                                                "Run Cost (%)" = "process_cost_perc",
+                                                "Average process cost" = "average_cost",
+                                                "Nr. of tasks" = "n_tasks"),
+                                   selection="none",
+                                   rownames= FALSE,
+                                   options = list(autoWidth = FALSE,
+                                                  language = list(search = 'Filter:'),
+                                                  pageLength = 10,
+                                                  order = list(list(2, 'asc')),
+                                                  initComplete = JS(
+                                                    "function(settings, json) {",
+                                                    "$('table').css({'font-size': '17px'});",
+                                                    "}"
+                                                  ))
+                                   ) %>%
+        formatStyle(
+          'Group',
+          target = 'row',
+          backgroundColor = styleEqual(
+            names(rgba_colors),
+            rgba_colors
+            )
+        )
+      )
+      
+      print(htmltools::tagList(
+        tags$style(HTML("
+      .dataTable thead th {
+        background-color: #160f26 !important;
+        color: white !important;
+        text-align: left !important;
+        white-space: nowrap;
+      }
+      .dataTable tbody td {
+        text-align: left !important;
+        white-space: nowrap;
+      }
+      .scrollable-table {
+        width: 100%;
+        overflow-x: auto;
+      }
+    ")
+        ),
+      process_cost_table))
+      
+    cat("\n\n")
+    cat(sprintf('<div style="margin-bottom: 40px;"></div>'))
+    
+  } # end of cost block
+  
+  ## Process runtime plot
+  task_data_pipe <- subset(task_data,pipeline == pipe)
+  
+  summary_data <- task_data_pipe %>%
+    group_by(process, group) %>%
+    summarise(
+      mean_runtime = mean(runtime_mins, na.rm = TRUE),
+      sd_value = sd(runtime_mins, na.rm = TRUE)
+    )
+
+  # Step 2: Add lower and upper bounds for the error bars
+  summary_data <- summary_data %>%
+    mutate(
+      value_lower = mean_runtime - sd_value,
+      value_upper = mean_runtime + sd_value
+    ) %>%
+    ungroup() %>%
+    arrange(desc(mean_runtime))
+  
+  ## Set order of processes based on average run time difference
+  summary_data$process <- factor(summary_data$process, 
+                                 levels = unique(summary_data$process))
+  
+  shared_data_summary_data <- SharedData$new(summary_data, key = ~process, group = pipe_crosstalk)
+    
+  
+  process_ggplot <- ggplot(shared_data_summary_data,aes(x = process, y = mean_runtime,
+                                            text = paste(process,"\n","Average run time (min): ",round(mean_runtime,2),sep=""))) +
+    geom_pointrange(
+      aes(ymin = mean_runtime-sd_value, ymax = mean_runtime+sd_value, color = group),
+      position = position_dodge(0.9)
+    ) +
+    seqera_light_theme() +
+    scale_color_manual(values = groups_color_palette) +
+    labs(x = "Processes",
+         y = "Task duration (minutes)",
+         title = "Task-duration distribution per process") +
+    # Hide y-axis text and ticks and line
+    theme(axis.text.x = element_blank(),
+          legend.title = element_text(face = "bold"),
+          # Hide facet box and labels
+          strip.background = element_blank(),
+          strip.text = element_blank(),
+          plot.title = element_text(size = plot_title_size)
+    )
+  
+  print(htmltools::tagList(
+    ggplotly(process_ggplot, tooltip = "text") %>%
+    highlight(on = "plotly_click", off = "plotly_doubleclick", opacityDim = 0.05) %>%
+    set_ggplotly_font()
+    )
+  )
+  
+  cat("\n\n")
+  cat(sprintf('<div style="margin-bottom: 40px;"></div>'))
+  
+}
+```

--- a/modules/local/benchmark_report/overrides/quarto_content/run_overview.qmd
+++ b/modules/local/benchmark_report/overrides/quarto_content/run_overview.qmd
@@ -1,0 +1,525 @@
+# Run overview
+
+::: {.callout-note .benchmark_callouts title="Summary"}
+This section provides a high-level overview of the pipeline run metrics.
+:::
+
+## Run summary
+
+Summary of pipeline execution and infrastructure settings.
+
+```{r}
+#| label: run-overview-table
+#| echo: false
+#| include: false
+#| results: hide
+#| 
+# Function to apply alpha to a hex color
+apply_alpha <- function(color, alpha) {
+  rgb <- col2rgb(color) / 255
+  sprintf("rgba(%d, %d, %d, %.2f)", rgb[1] * 255, rgb[2] * 255, rgb[3] * 255, alpha)
+}
+
+calculate_min_width <- function(column_data) {
+  max(nchar(as.character(column_data))) * 8  # Approximate width in pixels (adjust the multiplier as needed)
+}
+
+table_row_alpha_value <- 0.15
+
+
+view_table <- merged_logs %>%
+  mutate(
+    userName = if("userName" %in% colnames(.)) userName else NA,
+    workflow_revision = if("workflow_revision" %in% colnames(.)) workflow_revision else NA,
+    "nextflow.version" = if("nextflow.version" %in% colnames(.)) `nextflow.version` else NA,
+    "stats.succeedCount" = if("stats.succeedCount" %in% colnames(.)) `stats.succeedCount` else NA,
+    "stats.failedCount" = if("stats.failedCount" %in% colnames(.)) `stats.failedCount` else NA,
+    executors = if("executors" %in% colnames(.)) executors else NA,
+    "computeEnv.config.region" = if("computeEnv.config.region" %in% colnames(.)) `computeEnv.config.region` else NA,
+    "computeEnv.config.forge.type" = if("computeEnv.config.forge.type" %in% colnames(.)) `computeEnv.config.forge.type` else NA,
+    "computeEnv.config.forge.maxCpus" = if("computeEnv.config.forge.maxCpus" %in% colnames(.)) `computeEnv.config.forge.maxCpus` else NA,
+    "computeEnv.config.waveEnabled" = if("computeEnv.config.waveEnabled" %in% colnames(.)) `computeEnv.config.waveEnabled` else NA,
+    "computeEnv.config.fusion2Enabled" = if("computeEnv.config.fusion2Enabled" %in% colnames(.)) `computeEnv.config.fusion2Enabled` else NA,
+    "computeEnv.config.nvnmeStorageEnabled" = if("computeEnv.config.nvnmeStorageEnabled" %in% colnames(.)) `computeEnv.config.nvnmeStorageEnabled` else NA,
+    "computeEnv.config.forge.gpuEnabled" = if("computeEnv.config.forge.gpuEnabled" %in% colnames(.)) `computeEnv.config.forge.gpuEnabled` else NA,
+    "computeEnv.config.forge.ebsAutoScale" = if("computeEnv.config.forge.ebsAutoScale" %in% colnames(.)) `computeEnv.config.forge.ebsAutoScale` else NA
+  ) %>%
+  select(pipeline, group, run_id, userName, workflow_revision, "nextflow.version", version, 
+         "stats.succeedCount", "stats.failedCount", executors, "computeEnv.config.region",
+         "computeEnv.config.forge.type", "computeEnv.config.forge.maxCpus", "computeEnv.config.waveEnabled",
+         "computeEnv.config.fusion2Enabled", "computeEnv.config.nvnmeStorageEnabled",
+         "computeEnv.config.forge.gpuEnabled", "computeEnv.config.forge.ebsAutoScale") %>%
+  rename(
+    username = userName,
+    Version = workflow_revision,
+    Nextflow_version = "nextflow.version",
+    platform_version = version,
+    succeedCount = "stats.succeedCount",
+    failedCount = "stats.failedCount", 
+    executor = executors,
+    region = "computeEnv.config.region",
+    provisioning = "computeEnv.config.forge.type",
+    max_cpu = "computeEnv.config.forge.maxCpus",
+    waveEnabled = "computeEnv.config.waveEnabled",
+    fusion_enabled = "computeEnv.config.fusion2Enabled",
+    nvnmeStorageEnabled = "computeEnv.config.nvnmeStorageEnabled",
+    gpu_enabled = "computeEnv.config.forge.gpuEnabled",
+    ebs_autoscale = "computeEnv.config.forge.ebsAutoScale"
+  ) %>%
+  # Replace NA values in columns with enabled in name with false
+  mutate(across(ends_with("enabled"), ~ifelse(is.na(.), FALSE, .)))
+
+run_overview <- reactable(
+  view_table,
+  language = reactableLang(
+    searchPlaceholder = "Filter"
+    ),
+  defaultColDef = colDef(
+    align = "center",
+    minWidth = 150
+    ),
+   columns = list(
+    pipeline = colDef(name = "Pipeline<br>name",html = TRUE, align = "left",
+                       style = list(whiteSpace = "nowrap", overflow = "hidden", textOverflow = "ellipsis"),
+                      minWidth = 200,
+                       ),
+    group = colDef(name = "Group", html = TRUE, align = "left", minWidth = 150,),
+    run_id = colDef(name = "Run ID", html = TRUE, minWidth = 200, align = "left"),
+    username = colDef(name = "User<br>name", html = TRUE, minWidth = 180, align = "left"),
+    Version = colDef(name = "Pipeline<br>version", html = TRUE),
+    Nextflow_version = colDef(name = "Nextflow<br>version", html = TRUE),
+    platform_version = colDef(name = "Platform<br>version", html = TRUE, minWidth = 180),
+    succeedCount = colDef(name = "Tasks<br>succeeded", html = TRUE),
+    failedCount = colDef(name = "Tasks<br>failed", html = TRUE),
+    executor = colDef(name = "Executor"),
+    region = colDef(name = "Region"),
+    provisioning = colDef(name = "Provisioning<br>model", html = TRUE, minWidth = 150,),
+    max_cpu = colDef(name = "Max<br>CPUs", html = TRUE),
+    waveEnabled = colDef(name = "Wave<br>enabled", html = TRUE),
+    fusion_enabled = colDef(name = "Fusion<br>enabled", html = TRUE),
+    nvnmeStorageEnabled = colDef(name = "NVMe<br>enabled", html = TRUE),
+    gpu_enabled = colDef(name = "GPU<br>enabled", html = TRUE),
+    ebs_autoscale = colDef(name = "EBS<br>autoscale", html = TRUE)
+     ),
+  rowStyle = function(index) {
+    group <- view_table$group[index]
+    color <- groups_color_palette[[group]]
+    color_with_alpha <- apply_alpha(color, table_row_alpha_value)
+    list(background = color_with_alpha)
+  },
+  wrap = TRUE,
+  resizable = TRUE,
+  bordered = TRUE,
+  striped = FALSE,
+  highlight = TRUE,
+  searchable = TRUE,
+  defaultPageSize = 20
+)
+```
+
+::: {.callout-caution .benchmark_callouts collapse="false" icon="false"}
+## {{< fa table >}} Click to display table
+
+`r run_overview`
+:::
+
+## Run metrics
+
+This section provides a visual overview of the pipeline run metrics. Task-derived efficiencies are recomputed from the task logs, and optional scheduler/VM metrics are added when machine CSVs are available.
+
+```{r run-metrics}
+library(RColorBrewer)
+color_palette <- brewer.pal(8, "Set1")
+
+css_style <- "
+.reactable-cell .data-bar-text {
+  margin-right: 30px;  # Adjust this value to increase/decrease the distance
+}
+"
+
+cost_colname <- ""
+cost_colname_used <- ""
+cost_colname_unused <- ""
+
+# Custom formatter for percentage column
+format_percentage <- function(value) {
+  sprintf("%.2f%%", value)
+}
+
+## Add cost information, if requested
+if (grepl("cost",profile)) {
+  all_runs <- unique(cost_table$run_id)
+  
+  run_cost <- cost_table %>% 
+    group_by(run_id) %>%
+    subset(!is.na(cost)) %>%
+    summarise(cost = round(sum(cost),2),
+              used_cost = round(sum(used_cost),2),
+              unused_cost = round(sum(unused_cost),2)) %>%
+    select(run_id,cost,used_cost,unused_cost)
+  runs_with_some_cost <- run_cost$run_id
+  # Check if there is an NA in run_cost$cost and if so, break
+  if (!all(all_runs %in% runs_with_some_cost)){
+    # Check if all IDs in all_runs are found in runs_with_some_cost and if not, break
+    stop("Cost information is missing for some runs. Please check the cost report.")
+  }
+  
+  ## run_cost will contain accurate cost, if AWS reports provided
+  merged_logs <- merged_logs %>% select(-cost)
+  merged_logs <- left_join(merged_logs,run_cost,by="run_id")
+  cost_colname <- "Estimated<br>cost ($)"
+}
+
+if (params$aws_cost != "NA") {
+  cost_colname        <- "Compute<br>cost ($)"
+  cost_colname_used   <- "Used<br>compute<br>cost ($)"
+  cost_colname_unused <- "Unused<br>compute<br>cost ($)"
+}
+
+## Select which columns to keep
+if(grepl("cost",profile) & params$aws_cost != "NA") {
+    merged_logs <- merged_logs %>% select(any_of(c("pipeline","group","run_id","Wall_time","duration","cpuTime","task_runtime_ms","cost","readBytes","writeBytes","cpuEfficiency","memoryEfficiency","pipeline_workdirSize_GB","pipeline_workdirSize_price","used_cost","unused_cost","nMachines","vmCpuH","vmMemGibH","schedAllocCpuEfficiency","schedAllocMemEfficiency","realVmCpuEfficiency","realVmMemEfficiency","realCpuH","realMemGibH","requestedCpuH","requestedMemGibH")))
+}else {
+  merged_logs <- merged_logs %>% select(any_of(c("pipeline","group","run_id","Wall_time","duration","cpuTime","task_runtime_ms","cost","readBytes","writeBytes","cpuEfficiency","memoryEfficiency","pipeline_workdirSize_GB","pipeline_workdirSize_price","nMachines","vmCpuH","vmMemGibH","schedAllocCpuEfficiency","schedAllocMemEfficiency","realVmCpuEfficiency","realVmMemEfficiency","realCpuH","realMemGibH","requestedCpuH","requestedMemGibH")))
+}
+
+metrics_reactable <- merged_logs %>%
+  mutate(readBytes = round(readBytes,0),
+         writeBytes = round(writeBytes,0),
+         cpuEfficiency = round(cpuEfficiency,0),
+         memoryEfficiency = round(memoryEfficiency,4),
+         task_runtime_time = sapply(task_runtime_ms, milliseconds_to_hms)) %>%
+  arrange(pipeline)
+
+if("pipeline_workdirSize_GB" %in% colnames(metrics_reactable)) {
+  metrics_reactable <- metrics_reactable %>%
+    mutate(pipeline_workdirSize_GB = round(pipeline_workdirSize_GB,2),
+           pipeline_workdirSize_price = round(pipeline_workdirSize_price,2),)
+}
+
+# If cost profile not selected, drop costs
+if (!grepl("cost",profile) ) {
+  metrics_reactable <- metrics_reactable %>% select(-cost)
+}
+
+run_metrics_table <- reactable(metrics_reactable,
+                              language = reactableLang(
+                                searchPlaceholder = "Filter"
+                              ),
+                              defaultColDef = colDef(
+                                align = "center",
+                                minWidth = 180),
+                              columns = list(
+                                pipeline = colDef(name = "Pipeline<br>name", html = TRUE,align = "left",
+                                                  width = 200,  # Set an appropriate width
+                                                  style = list(whiteSpace = "nowrap", overflow = "hidden", 
+                                                               textOverflow = "ellipsis")
+                                ),
+                                group = colDef(name = "group",align = "left",),
+                                run_id = colDef(name = "Run ID", html = TRUE, minWidth = 180, align = "left",),
+                                Wall_time = colDef(name = "Wall<br>time", html = TRUE,
+                                                   cell = data_bars(metrics_reactable, fill_color = color_palette[1],
+                                                                    fill_by = "duration",
+                                                                    force_outside = c(0,0.5*max(metrics_reactable$duration))
+                                                                    )
+                                ),
+                                duration = colDef(show = FALSE),
+                                cpuTime    = colDef(name = "CPU<br>time (hours)", html = TRUE, format = colFormat(digits = 1),
+                                                 cell = data_bars(metrics_reactable, text_color = "black",  fill_color = color_palette[2],
+                                                                  fill_by = "cpuTime", 
+                                                                  text_position = "inside-end", force_outside = c(0,0.5*max(metrics_reactable$cpuTime))
+                                                                  )
+                                                 ),
+                                task_runtime_ms = colDef(show = FALSE),
+                                task_runtime_time = colDef(name = "Total task<br>runtime", html = TRUE,
+                                                   cell = data_bars(metrics_reactable, fill_color = color_palette[8],
+                                                                    fill_by = "task_runtime_ms",
+                                                                    force_outside = c(0,0.5*max(metrics_reactable$task_runtime_ms)))
+                                ),
+                              cost       = colDef(name = cost_colname, html = TRUE, 
+                                              cell = data_bars(metrics_reactable, fill_color = color_palette[3], fill_by = "cost",
+                                                               force_outside = c(0,0.5*max(metrics_reactable$cost))
+                                                               )),
+                              used_cost   = colDef(name = cost_colname_used, html = TRUE, 
+                                                    cell = data_bars(metrics_reactable, fill_color = color_palette[3], 
+                                                                     fill_by = "used_cost",
+                                                                     force_outside = c(0,0.5*max(metrics_reactable$used_cost))
+                                                                     )),
+                              unused_cost       = colDef(name = cost_colname_unused, html = TRUE, 
+                                                    cell = data_bars(metrics_reactable, fill_color = color_palette[3], fill_by = "unused_cost",
+                                                                     force_outside = c(0,0.5*max(metrics_reactable$unused_cost))
+                                                                     )),
+                               pipeline_workdirSize_GB       = colDef(name = "Workdir size (GB)", html = TRUE, 
+                                              cell = data_bars(metrics_reactable, fill_color = color_palette[3], fill_by = "pipeline_workdirSize_GB",
+                                                               force_outside = c(0,0.5*max(metrics_reactable$cost))
+                                                               )),
+                               pipeline_workdirSize_price       = colDef(name = "Workdir storage<br>cost monthly ($)", html = TRUE, 
+                                              cell = data_bars(metrics_reactable, fill_color = color_palette[3], fill_by = "pipeline_workdirSize_price",
+                                                               force_outside = c(0,0.5*max(metrics_reactable$cost))
+                                                               )),
+                                readBytes  = colDef(name = "Read<br>(GB)", html = TRUE, 
+                                                   cell = data_bars(metrics_reactable, fill_color = color_palette[4], fill_by = "readBytes",
+                                                                    force_outside = c(0,0.5*max(metrics_reactable$readBytes))
+                                                                    )),
+                                writeBytes = colDef(name = "Write<br>(GB)", html = TRUE, 
+                                                    cell = data_bars(metrics_reactable, fill_color = color_palette[5], fill_by = "writeBytes",
+                                                                     force_outside = c(0,0.5*max(metrics_reactable$writeBytes))
+                                                                     )),
+                                cpuEfficiency = colDef(name = "Task CPU<br>efficiency (%)", html = TRUE, 
+                                                       cell = data_bars(metrics_reactable, fill_color = color_palette[6], fill_by = "cpuEfficiency",
+                                                                        force_outside = c(0,0.5*max(metrics_reactable$cpuEfficiency))
+                                                                        )),
+                                memoryEfficiency = colDef(name = "Task memory<br>efficiency (%)", html = TRUE,
+                                                          cell = data_bars(metrics_reactable, fill_color = color_palette[7], fill_by = "memoryEfficiency",
+                                                                           force_outside = c(0,0.5*max(metrics_reactable$memoryEfficiency))
+                                                                           ))
+                              ),
+                              rowStyle = function(index) {
+                                group <- view_table$group[index]
+                                color <- groups_color_palette[[group]]
+                                color_with_alpha <- apply_alpha(color, table_row_alpha_value)
+                                list(background = color_with_alpha)
+                              },
+                              style = list(css = css_style),
+                              wrap = FALSE,
+                              resizable = TRUE,
+                              bordered = TRUE,
+                              striped = FALSE,
+                              highlight = TRUE,
+                              filterable = FALSE,
+                              searchable = TRUE,
+                              defaultPageSize = 20,
+                              elementId = "metrics-table"
+)
+```
+
+```{r download-button-run-overview}
+library(htmltools)
+
+download_button <- HTML('
+  <style>
+    .download-button {
+      background-color: #160F26; /* Green background */
+      border: none; /* Remove borders */
+      color: white; /* White text */
+      padding: 10px 10px; /* Some padding */
+      text-align: center; /* Center the text */
+      text-decoration: none; /* Remove underline */
+      display: inline-block; /* Make the button inline */
+      font-size: 17px; /* Increase font size */
+      margin: 4px 2px; /* Add some margin */
+      cursor: pointer; /* Pointer/hand icon */
+      border-radius: 5px; /* Rounded corners */
+    }
+    .download-button:hover {
+      background-color: #0DC09D; /* Darker green on hover */
+    }
+  </style>
+  <button class="download-button" onclick="Reactable.downloadDataCSV(\'metrics-table\', \'run_overview.csv\')">
+    Download as CSV
+  </button>
+')
+```
+
+::: {.callout-caution .benchmark_callouts collapse="true" icon="false"}
+## {{< fa table >}} Click to display table
+
+`r run_metrics_table`
+
+<center>`r download_button`</center>
+:::
+
+```{r}
+# Set dynamic figure height
+fig_height <- 10 + 3 * n_groups
+```
+
+
+```{r run-metrics-plot}
+#| fig-width: 12
+#| fig-height: !expr fig_height
+
+## Generate table for metrics plot based on whether cost parameter is set to true
+if (grepl("cost",profile)) {
+    metrics_table <- merged_logs %>% select(any_of(c("pipeline","group","run_id","Wall_time","duration","cpuTime","readBytes","writeBytes","cpuEfficiency","memoryEfficiency","task_runtime_ms","pipeline_workdirSize_GB","pipeline_workdirSize_price","cost","used_cost","unused_cost")))
+    if("pipeline_workdirSize_GB" %in% colnames(metrics_table)){
+      metrics <- c("Wall_time","cost","used_cost","unused_cost","task_runtime_ms","cpuTime","readBytes", "writeBytes", "cpuEfficiency", "memoryEfficiency","pipeline_workdirSize_GB","pipeline_workdirSize_price")
+      ## Create a labeler for facets
+      metrics_formatted <- c("Wall time (HH:MM:SS)","Estimated compute cost ($)","Estimated used compute cost ($)","Estimated unused compute cost ($)", "Total task runtime (HH:MM:SS)","CPU time (hours)", "Read (GB)", "Write (GB)", "Task CPU efficiency (%)", "Task memory efficiency (%)","Workdir size (GB)","Workdir storage cost monthly ($)")
+    }else{
+      metrics <- c("Wall_time","cost","used_cost","unused_cost","task_runtime_ms","cpuTime","readBytes", "writeBytes", "cpuEfficiency", "memoryEfficiency")
+      metrics_formatted <- c("Wall time (HH:MM:SS)","Estimated compute cost ($)","Estimated used compute cost ($)","Estimated unused compute cost ($)", "Total task runtime (HH:MM:SS)","CPU time (hours)", "Read (GB)", "Write (GB)", "Task CPU efficiency (%)", "Task memory efficiency (%)")
+    }
+
+    if (params$aws_cost != "NA") {
+      # Replace Estimated cost ($) with Accurate<br>cost ($) in vector metrics_formatted
+      metrics_formatted[metrics_formatted == "Estimated compute cost ($)"]        <- "Accurate compute cost ($)"
+      metrics_formatted[metrics_formatted == "Estimated used compute cost ($)"]   <- "Accurate used compute cost ($)"
+      metrics_formatted[metrics_formatted == "Estimated unused compute cost ($)"] <- "Accurate unused compute cost ($)"
+    }
+    labels <- setNames(metrics_formatted, metrics)
+  } else {
+    metrics_table <- merged_logs %>% select(any_of(c("pipeline","group","run_id","Wall_time","duration","cpuTime","readBytes","writeBytes","cpuEfficiency","memoryEfficiency","task_runtime_ms","pipeline_workdirSize_GB","pipeline_workdirSize_price")))
+    
+    if("pipeline_workdirSize_GB" %in% colnames(metrics_table)){
+      metrics <- c("Wall_time","cpuTime","task_runtime_ms","readBytes", "writeBytes", "cpuEfficiency", "memoryEfficiency","pipeline_workdirSize_GB","pipeline_workdirSize_price")
+      ## Create a labeler for facets
+      metrics_formatted <- c("Wall time (HH:MM:SS)", "CPU time (hours)","Total task runtime (HH:MM:SS)", "Read (GB)", "Write (GB)", "Task CPU efficiency (%)", "Task memory efficiency (%)","Workdir size (GB)","Workdir storage cost monthly ($)")
+    }else{
+    metrics_table <- merged_logs %>% select(any_of(c("pipeline","group","run_id","Wall_time","duration","cpuTime","readBytes","writeBytes","cpuEfficiency","memoryEfficiency","task_runtime_ms")))
+    metrics <- c("Wall_time","cpuTime","task_runtime_ms","readBytes", "writeBytes", "cpuEfficiency", "memoryEfficiency")
+    ## Create a labeler for facets
+    metrics_formatted <- c("Wall time (HH:MM:SS)", "CPU time (hours)","Total task runtime (HH:MM:SS)", "Read (GB)", "Write (GB)", "Task CPU efficiency (%)", "Task memory efficiency (%)")
+    }
+
+    labels <- setNames(metrics_formatted, metrics)
+  }
+
+metrics_table <- metrics_table %>% arrange(pipeline)
+
+metrics_table_long <- metrics_table %>%
+  mutate("Wall_time" = as.numeric(duration),
+         "readBytes" = as.numeric(readBytes),
+         "writeBytes" = as.numeric(writeBytes)
+         ) %>%
+  pivot_longer(cols = metrics,
+               names_to = "Metric", values_to = "Value") %>%
+  # Round all values except wall time and cost to 0 decimal places
+  mutate(Value = if_else(Metric %in% c("Wall_time","task_runtime_ms","cost","used_cost","unused_cost"),Value,round(Value, 0))
+         )
+
+## Set order of facets
+metrics_table_long$Metric <- factor(metrics_table_long$Metric,
+                                    levels = metrics)
+
+## Reverse order for flipped barplot
+metrics_table_long$group <- factor(metrics_table_long$group, levels = rev(levels(metrics_table_long$group)))
+
+## If a pipeline was run more than once, we show the mean for the barplot and points for the replicates. The text also shows the mean and is repositioned.
+if(n_runs_max > 1){
+  # Calculate mean values for text and text positioning
+  means <- metrics_table_long %>%
+    ungroup() %>%
+    group_by(Group,Metric,pipeline) %>%
+    summarise(mean_points = mean(as.numeric(Value)),
+              max_value = max(as.numeric(Value))) %>%
+    mutate(Formatted_Value = ifelse(Metric %in% c("Wall_time","task_runtime_ms"), sapply(mean_points, milliseconds_to_hms), 
+                                      if_else(Metric == "cost",as.character(round(mean_points,2)),
+                                              as.character(round(mean_points, 0))))
+           )
+  
+
+  metrics_plot <- ggplot(metrics_table_long,
+                         aes(x = Value, y = pipeline, group = group)
+                         ) +
+    geom_bar(aes(fill = group),stat = "summary",fun.y = "mean", position = "dodge", width = 0.75, color = "#160F26") +
+    scale_fill_manual(values = groups_color_palette) +
+    geom_point(aes(fill = group,
+                   text = paste("run_id: ", run_id,"\n",
+                                "Value: ", ifelse(Metric %in% c("Wall_time","task_runtime_ms"), sapply(Value, milliseconds_to_hms), as.character(Value)))
+                                ),
+               position = position_dodge(width = 0.75),  size = 3,
+               #color = "black", show.legend = FALSE
+               shape = 21, color = "black", show.legend = FALSE
+               )
+  
+}else{ # If a pipeline was run only once
+  metrics_table_long <- metrics_table_long %>%
+    mutate(Formatted_Value = ifelse(Metric %in% c("Wall_time","task_runtime_ms"), sapply(Value, milliseconds_to_hms), as.character(Value)))
+  
+  metrics_table_long$group <- factor(metrics_table_long$group, levels = levels(metrics_table_long$group))
+
+  metrics_plot <- ggplot(metrics_table_long,
+                         aes(x = Value, y = pipeline, fill = group)) +
+      geom_bar(stat = "identity", position = "dodge", width = 0.75,color = "#160F26") +
+      geom_text(aes(label = pad_labels(ifelse(Metric %in% c("Wall_time","task_runtime_ms"), Formatted_Value, Value))),
+            position = position_dodge(width = 0.75),
+            hjust = -0.2, 
+            size = 3.5,
+            color = "#160F26"
+            ) +
+    scale_fill_manual(values = groups_color_palette)
+}
+
+metrics_plot <- metrics_plot + 
+  facet_wrap(~ Metric, scales = "free_x", ncol = 2, labeller = as_labeller(labels)) +
+  labs(
+    x = "",
+    y = "",
+    fill = "group"
+  ) +
+  theme(legend.position = "top") +
+  # Reverse order of legend keys
+  guides(fill = guide_legend(reverse = TRUE)) +
+  # Hide x-axis completely
+  theme(axis.title.x = element_blank(),
+        # axis.text.x = element_blank(),
+        # axis.ticks.x = element_blank(),
+        axis.line.x = element_blank()) +
+  seqera_light_theme() +
+  scale_x_continuous(limits = expand_x_limits) 
+
+if(n_runs_max > 1){
+  ggplotly(metrics_plot, tooltip = c("text"))
+}else{
+  metrics_plot
+}
+```
+
+```{r vm-metrics-table}
+#| echo: false
+#| results: asis
+
+vm_metrics_cols <- c("nMachines", "vmCpuH", "vmMemGibH", "schedAllocCpuEfficiency", "schedAllocMemEfficiency", "realVmCpuEfficiency", "realVmMemEfficiency", "realCpuH", "realMemGibH", "requestedCpuH", "requestedMemGibH")
+
+if (all(vm_metrics_cols %in% colnames(metrics_reactable)) && any(!is.na(metrics_reactable$vmCpuH))) {
+  cat("## Scheduler VM metrics\n\n")
+  cat("These values are computed from optional machine CSVs when they are provided alongside each run dump. Task efficiencies are derived from task logs, while VM efficiencies relate those task metrics back to total machine lifetime capacity.\n\n")
+
+  vm_metrics_table <- metrics_reactable %>%
+    select(pipeline, group, run_id, all_of(vm_metrics_cols)) %>%
+    mutate(
+      vmCpuH = round(vmCpuH, 2),
+      vmMemGibH = round(vmMemGibH, 2),
+      schedAllocCpuEfficiency = round(schedAllocCpuEfficiency, 2),
+      schedAllocMemEfficiency = round(schedAllocMemEfficiency, 2),
+      realVmCpuEfficiency = round(realVmCpuEfficiency, 2),
+      realVmMemEfficiency = round(realVmMemEfficiency, 2),
+      realCpuH = round(realCpuH, 2),
+      realMemGibH = round(realMemGibH, 2),
+      requestedCpuH = round(requestedCpuH, 2),
+      requestedMemGibH = round(requestedMemGibH, 2)
+    )
+
+  vm_metrics_reactable <- reactable(
+    vm_metrics_table,
+    language = reactableLang(searchPlaceholder = "Filter"),
+    defaultColDef = colDef(align = "center", minWidth = 140),
+    columns = list(
+      pipeline = colDef(name = "Pipeline<br>name", html = TRUE, align = "left"),
+      group = colDef(align = "left"),
+      run_id = colDef(name = "Run ID", align = "left"),
+      nMachines = colDef(name = "Machines"),
+      vmCpuH = colDef(name = "VM CPU<br>hours", html = TRUE),
+      vmMemGibH = colDef(name = "VM memory<br>GiB hours", html = TRUE),
+      schedAllocCpuEfficiency = colDef(name = "Scheduler CPU<br>efficiency (%)", html = TRUE),
+      schedAllocMemEfficiency = colDef(name = "Scheduler memory<br>efficiency (%)", html = TRUE),
+      realVmCpuEfficiency = colDef(name = "Real VM CPU<br>efficiency (%)", html = TRUE),
+      realVmMemEfficiency = colDef(name = "Real VM memory<br>efficiency (%)", html = TRUE),
+      realCpuH = colDef(name = "Real CPU<br>hours", html = TRUE),
+      realMemGibH = colDef(name = "Real memory<br>GiB hours", html = TRUE),
+      requestedCpuH = colDef(name = "Requested CPU<br>hours", html = TRUE),
+      requestedMemGibH = colDef(name = "Requested memory<br>GiB hours", html = TRUE)
+    ),
+    wrap = FALSE,
+    resizable = TRUE,
+    bordered = TRUE,
+    striped = FALSE,
+    highlight = TRUE,
+    searchable = TRUE,
+    defaultPageSize = 20
+  )
+
+  print(vm_metrics_reactable)
+}
+```

--- a/modules/local/benchmark_report/overrides/quarto_content/run_overview.qmd
+++ b/modules/local/benchmark_report/overrides/quarto_content/run_overview.qmd
@@ -125,7 +125,7 @@ run_overview <- reactable(
 
 ## Run metrics
 
-This section provides a visual overview of the pipeline run metrics. Task-derived efficiencies are recomputed from the task logs, and optional scheduler/VM metrics are added when machine CSVs are available.
+This section provides a visual overview of the pipeline run metrics. When machine CSVs are available, the report also decomposes each run into four layers: user-requested resources, scheduler-booked resources, real task usage, and total VM capacity.
 
 ```{r run-metrics}
 library(RColorBrewer)
@@ -177,10 +177,23 @@ if (params$aws_cost != "NA") {
 }
 
 ## Select which columns to keep
+vm_layer_metric_cols <- c(
+  "nMachines", "vmCpuH", "vmMemGibH",
+  "requestedCpuH", "requestedMemGibH",
+  "requestedVmCpuEfficiency", "requestedVmMemEfficiency",
+  "schedAllocCpuEfficiency", "schedAllocMemEfficiency",
+  "schedulerBookedCpuH", "schedulerBookedMemGibH",
+  "schedulerRightsizedCpuH", "schedulerRightsizedMemGibH",
+  "schedulerOverbookCpuH", "schedulerOverbookMemGibH",
+  "vmPackingSlackCpuH", "vmPackingSlackMemGibH",
+  "realVmCpuEfficiency", "realVmMemEfficiency",
+  "realCpuH", "realMemGibH"
+)
+
 if(grepl("cost",profile) & params$aws_cost != "NA") {
-    merged_logs <- merged_logs %>% select(any_of(c("pipeline","group","run_id","Wall_time","duration","cpuTime","task_runtime_ms","cost","readBytes","writeBytes","cpuEfficiency","memoryEfficiency","pipeline_workdirSize_GB","pipeline_workdirSize_price","used_cost","unused_cost","nMachines","vmCpuH","vmMemGibH","schedAllocCpuEfficiency","schedAllocMemEfficiency","realVmCpuEfficiency","realVmMemEfficiency","realCpuH","realMemGibH","requestedCpuH","requestedMemGibH")))
+    merged_logs <- merged_logs %>% select(any_of(c("pipeline","group","run_id","Wall_time","duration","cpuTime","task_runtime_ms","cost","readBytes","writeBytes","cpuEfficiency","memoryEfficiency","pipeline_workdirSize_GB","pipeline_workdirSize_price","used_cost","unused_cost", vm_layer_metric_cols)))
 }else {
-  merged_logs <- merged_logs %>% select(any_of(c("pipeline","group","run_id","Wall_time","duration","cpuTime","task_runtime_ms","cost","readBytes","writeBytes","cpuEfficiency","memoryEfficiency","pipeline_workdirSize_GB","pipeline_workdirSize_price","nMachines","vmCpuH","vmMemGibH","schedAllocCpuEfficiency","schedAllocMemEfficiency","realVmCpuEfficiency","realVmMemEfficiency","realCpuH","realMemGibH","requestedCpuH","requestedMemGibH")))
+  merged_logs <- merged_logs %>% select(any_of(c("pipeline","group","run_id","Wall_time","duration","cpuTime","task_runtime_ms","cost","readBytes","writeBytes","cpuEfficiency","memoryEfficiency","pipeline_workdirSize_GB","pipeline_workdirSize_price", vm_layer_metric_cols)))
 }
 
 metrics_reactable <- merged_logs %>%
@@ -466,29 +479,34 @@ if(n_runs_max > 1){
 }
 ```
 
+## Scheduler VM metrics
+
 ```{r vm-metrics-table}
 #| echo: false
 #| results: asis
 
-vm_metrics_cols <- c("nMachines", "vmCpuH", "vmMemGibH", "schedAllocCpuEfficiency", "schedAllocMemEfficiency", "realVmCpuEfficiency", "realVmMemEfficiency", "realCpuH", "realMemGibH", "requestedCpuH", "requestedMemGibH")
+vm_metrics_cols <- c(
+  "nMachines", "vmCpuH", "vmMemGibH",
+  "requestedCpuH", "requestedMemGibH",
+  "requestedVmCpuEfficiency", "requestedVmMemEfficiency",
+  "schedulerBookedCpuH", "schedulerBookedMemGibH",
+  "schedAllocCpuEfficiency", "schedAllocMemEfficiency",
+  "realCpuH", "realMemGibH",
+  "realVmCpuEfficiency", "realVmMemEfficiency",
+  "schedulerRightsizedCpuH", "schedulerRightsizedMemGibH",
+  "schedulerOverbookCpuH", "schedulerOverbookMemGibH",
+  "vmPackingSlackCpuH", "vmPackingSlackMemGibH"
+)
 
-if (all(vm_metrics_cols %in% colnames(metrics_reactable)) && any(!is.na(metrics_reactable$vmCpuH))) {
-  cat("## Scheduler VM metrics\n\n")
-  cat("These values are computed from optional machine CSVs when they are provided alongside each run dump. Task efficiencies are derived from task logs, while VM efficiencies relate those task metrics back to total machine lifetime capacity.\n\n")
+has_vm_metrics <- all(vm_metrics_cols %in% colnames(metrics_reactable)) && any(!is.na(metrics_reactable$vmCpuH))
+
+if (has_vm_metrics) {
+  cat("These values separate the three scheduler layers the benchmark cares about: user-requested resources, scheduler-booked resources, and VM capacity. `*-Predv1` groups can show positive scheduler right-sizing, while `Batch-*` groups act as the AWS Batch baseline without Seqera scheduler right-sizing.\n\n")
 
   vm_metrics_table <- metrics_reactable %>%
     select(pipeline, group, run_id, all_of(vm_metrics_cols)) %>%
     mutate(
-      vmCpuH = round(vmCpuH, 2),
-      vmMemGibH = round(vmMemGibH, 2),
-      schedAllocCpuEfficiency = round(schedAllocCpuEfficiency, 2),
-      schedAllocMemEfficiency = round(schedAllocMemEfficiency, 2),
-      realVmCpuEfficiency = round(realVmCpuEfficiency, 2),
-      realVmMemEfficiency = round(realVmMemEfficiency, 2),
-      realCpuH = round(realCpuH, 2),
-      realMemGibH = round(realMemGibH, 2),
-      requestedCpuH = round(requestedCpuH, 2),
-      requestedMemGibH = round(requestedMemGibH, 2)
+      across(-c(pipeline, group, run_id), ~ round(.x, 2))
     )
 
   vm_metrics_reactable <- reactable(
@@ -502,14 +520,24 @@ if (all(vm_metrics_cols %in% colnames(metrics_reactable)) && any(!is.na(metrics_
       nMachines = colDef(name = "Machines"),
       vmCpuH = colDef(name = "VM CPU<br>hours", html = TRUE),
       vmMemGibH = colDef(name = "VM memory<br>GiB hours", html = TRUE),
-      schedAllocCpuEfficiency = colDef(name = "Scheduler CPU<br>efficiency (%)", html = TRUE),
-      schedAllocMemEfficiency = colDef(name = "Scheduler memory<br>efficiency (%)", html = TRUE),
-      realVmCpuEfficiency = colDef(name = "Real VM CPU<br>efficiency (%)", html = TRUE),
-      realVmMemEfficiency = colDef(name = "Real VM memory<br>efficiency (%)", html = TRUE),
-      realCpuH = colDef(name = "Real CPU<br>hours", html = TRUE),
-      realMemGibH = colDef(name = "Real memory<br>GiB hours", html = TRUE),
-      requestedCpuH = colDef(name = "Requested CPU<br>hours", html = TRUE),
-      requestedMemGibH = colDef(name = "Requested memory<br>GiB hours", html = TRUE)
+      requestedCpuH = colDef(name = "User requested<br>CPU hours", html = TRUE),
+      requestedMemGibH = colDef(name = "User requested<br>memory GiB hours", html = TRUE),
+      requestedVmCpuEfficiency = colDef(name = "User requested / VM<br>CPU (%)", html = TRUE),
+      requestedVmMemEfficiency = colDef(name = "User requested / VM<br>memory (%)", html = TRUE),
+      schedulerBookedCpuH = colDef(name = "Scheduler booked<br>CPU hours", html = TRUE),
+      schedulerBookedMemGibH = colDef(name = "Scheduler booked<br>memory GiB hours", html = TRUE),
+      schedAllocCpuEfficiency = colDef(name = "Scheduler booked / VM<br>CPU (%)", html = TRUE),
+      schedAllocMemEfficiency = colDef(name = "Scheduler booked / VM<br>memory (%)", html = TRUE),
+      realCpuH = colDef(name = "Real used<br>CPU hours", html = TRUE),
+      realMemGibH = colDef(name = "Real used<br>memory GiB hours", html = TRUE),
+      realVmCpuEfficiency = colDef(name = "Real used / VM<br>CPU (%)", html = TRUE),
+      realVmMemEfficiency = colDef(name = "Real used / VM<br>memory (%)", html = TRUE),
+      schedulerRightsizedCpuH = colDef(name = "Scheduler right-sized<br>CPU hours", html = TRUE),
+      schedulerRightsizedMemGibH = colDef(name = "Scheduler right-sized<br>memory GiB hours", html = TRUE),
+      schedulerOverbookCpuH = colDef(name = "Scheduler over-booked<br>CPU hours", html = TRUE),
+      schedulerOverbookMemGibH = colDef(name = "Scheduler over-booked<br>memory GiB hours", html = TRUE),
+      vmPackingSlackCpuH = colDef(name = "VM packing slack<br>CPU hours", html = TRUE),
+      vmPackingSlackMemGibH = colDef(name = "VM packing slack<br>memory GiB hours", html = TRUE)
     ),
     wrap = FALSE,
     resizable = TRUE,
@@ -521,5 +549,166 @@ if (all(vm_metrics_cols %in% colnames(metrics_reactable)) && any(!is.na(metrics_
   )
 
   print(vm_metrics_reactable)
+}
+```
+
+## Performance gains
+
+```{r performance-gains}
+#| echo: false
+#| results: asis
+#| fig-width: 12
+#| fig-height: 6
+
+if (has_vm_metrics) {
+  performance_layers <- metrics_reactable %>%
+    filter(!is.na(vmCpuH), vmCpuH > 0) %>%
+    mutate(
+      display_group = as.character(group),
+      display_label = if (dplyr::n_distinct(group) == n()) display_group else paste0(display_group, " / ", run_id)
+    ) %>%
+    arrange(vmCpuH)
+
+  cat("This section attributes paid VM capacity to the three scheduler responsibilities you called out: provisioning, packing, and task right-sizing. `User requested` comes from the Nextflow task directives, `scheduler booked` comes from machine-level scheduler allocation, `real used` comes from observed task usage, and `VM capacity` comes from total machine lifetime.\n\n")
+  cat("For `*-Predv1` runs, scheduler right-sizing is estimated from aggregate `/machines` utilization. When that aggregate is noisier than the right-sizing signal, the report clamps negative right-sizing to zero. That is an under-count, not evidence that right-sizing was absent.\n\n")
+}
+```
+
+```{r performance-gains-cpu-mix}
+#| echo: false
+#| warning: false
+#| message: false
+#| fig-width: 12
+#| fig-height: 5
+
+if (has_vm_metrics) {
+  cpu_mix_data <- performance_layers %>%
+    transmute(
+      display_label,
+      `Used (real work)` = realCpuH,
+      `Scheduler over-booked` = schedulerOverbookCpuH,
+      `VM slack (packing)` = vmPackingSlackCpuH
+    ) %>%
+    pivot_longer(-display_label, names_to = "layer", values_to = "hours")
+
+  cpu_mix_plot <- ggplot(cpu_mix_data, aes(x = display_label, y = hours, fill = layer)) +
+    geom_col(color = "#160F26") +
+    coord_flip() +
+    scale_fill_manual(values = c(
+      "Used (real work)" = "#065647",
+      "Scheduler over-booked" = "#2b8cbe",
+      "VM slack (packing)" = "#cfd0d1"
+    )) +
+    labs(
+      title = "Performance gains: CPU capacity mix",
+      subtitle = "Total bar = VM CPU-hours paid for",
+      x = "",
+      y = "CPU-hours",
+      fill = ""
+    ) +
+    seqera_light_theme() +
+    theme(legend.position = "top")
+
+  print(cpu_mix_plot)
+}
+```
+
+```{r performance-gains-mem-mix}
+#| echo: false
+#| warning: false
+#| message: false
+#| fig-width: 12
+#| fig-height: 5
+
+if (has_vm_metrics) {
+  mem_mix_data <- performance_layers %>%
+    transmute(
+      display_label,
+      `Used (real work)` = realMemGibH,
+      `Scheduler over-booked` = schedulerOverbookMemGibH,
+      `VM slack (packing)` = vmPackingSlackMemGibH
+    ) %>%
+    pivot_longer(-display_label, names_to = "layer", values_to = "hours")
+
+  mem_mix_plot <- ggplot(mem_mix_data, aes(x = display_label, y = hours, fill = layer)) +
+    geom_col(color = "#160F26") +
+    coord_flip() +
+    scale_fill_manual(values = c(
+      "Used (real work)" = "#065647",
+      "Scheduler over-booked" = "#2b8cbe",
+      "VM slack (packing)" = "#cfd0d1"
+    )) +
+    labs(
+      title = "Performance gains: Memory capacity mix",
+      subtitle = "Total bar = VM memory GiB-hours paid for",
+      x = "",
+      y = "GiB-hours",
+      fill = ""
+    ) +
+    seqera_light_theme() +
+    theme(legend.position = "top")
+
+  print(mem_mix_plot)
+}
+```
+
+```{r performance-gains-savings}
+#| echo: false
+#| warning: false
+#| message: false
+#| fig-width: 12
+#| fig-height: 8
+
+if (has_vm_metrics) {
+  savings_cpu_data <- performance_layers %>%
+    transmute(
+      display_label,
+      `Scheduler right-sized (already saved)` = schedulerRightsizedCpuH,
+      `Scheduler over-booked (remaining)` = schedulerOverbookCpuH,
+      `VM packing slack` = vmPackingSlackCpuH
+    ) %>%
+    pivot_longer(-display_label, names_to = "layer", values_to = "hours")
+
+  savings_mem_data <- performance_layers %>%
+    transmute(
+      display_label,
+      `Scheduler right-sized (already saved)` = schedulerRightsizedMemGibH,
+      `Scheduler over-booked (remaining)` = schedulerOverbookMemGibH,
+      `VM packing slack` = vmPackingSlackMemGibH
+    ) %>%
+    pivot_longer(-display_label, names_to = "layer", values_to = "hours")
+
+  savings_palette <- c(
+    "Scheduler right-sized (already saved)" = "#43b48d",
+    "Scheduler over-booked (remaining)" = "#2b8cbe",
+    "VM packing slack" = "#cfd0d1"
+  )
+
+  cpu_savings_plot <- ggplot(savings_cpu_data, aes(x = display_label, y = hours, fill = layer)) +
+    geom_col(color = "#160F26") +
+    scale_fill_manual(values = savings_palette) +
+    labs(
+      title = "Potential savings by layer (CPU)",
+      x = "",
+      y = "CPU-hours",
+      fill = ""
+    ) +
+    seqera_light_theme() +
+    theme(legend.position = "top")
+
+  mem_savings_plot <- ggplot(savings_mem_data, aes(x = display_label, y = hours, fill = layer)) +
+    geom_col(color = "#160F26") +
+    scale_fill_manual(values = savings_palette) +
+    labs(
+      title = "Potential savings by layer (Memory)",
+      x = "",
+      y = "GiB-hours",
+      fill = ""
+    ) +
+    seqera_light_theme() +
+    theme(legend.position = "top")
+
+  print(cpu_savings_plot)
+  print(mem_savings_plot)
 }
 ```

--- a/modules/local/benchmark_report/overrides/quarto_content/task_overview.qmd
+++ b/modules/local/benchmark_report/overrides/quarto_content/task_overview.qmd
@@ -1,0 +1,607 @@
+---
+format: 
+  html:
+    include-in-header:
+      - text: |
+          <link href="https://cdn.datatables.net/1.10.24/css/jquery.dataTables.css" rel="stylesheet"/>
+          <link href="https://cdn.datatables.net/buttons/1.7.0/css/buttons.dataTables.min.css" rel="stylesheet"/>
+          <script src="https://cdn.datatables.net/buttons/1.7.0/js/dataTables.buttons.min.js"></script>
+          <script src="https://cdn.datatables.net/buttons/1.7.0/js/buttons.html5.min.js"></script>
+---
+
+# Task overview
+
+::: {.callout-note .benchmark_callouts title="Summary"}
+This section provides an overview of task-level metrics for instance usage and runtime metrics.
+:::
+
+## Task instance usage
+
+::: {.callout-tip .benchmark_callouts title="Plot interaction" collapse="true"}
+-   Hover over any bar to see the number of tasks per instance type
+-   Single-click on entries in the legend to hide specific instance types
+-   Double-click on entries in the legend to show specific instance types
+:::
+
+
+```{r task-instance-usage-plot}
+#| fig-width: 12
+#| fig-height: 12
+
+## Use the tasks logs to summarize how many different tasks were run on which instance types
+summary_tasks <- task_data %>%
+  group_by(run_id,group, machineType) %>%
+  summarise(n = n()) %>%
+  ungroup() %>%
+  arrange(desc(n))
+
+## Replace NA by "HPC" for slurm runs
+executors <- unique(task_data$executor)
+if("local" %in% executors){
+  summary_tasks$machineType[is.na(summary_tasks$machineType)] <- "local"
+}else{
+  summary_tasks$machineType[is.na(summary_tasks$machineType)] <- "HPC"
+}
+
+
+## Add pipeline name to run_id
+summary_tasks <- full_join(summary_tasks,merged_logs %>% select(run_id,pipeline),by="run_id") %>%
+  select(group,pipeline,run_id,machineType,n)
+
+summary_tasks$pipeline <- factor(summary_tasks$pipeline,
+                               levels = rev(pipeline_order))
+
+# Split the data by the facet variable
+split_data <- summary_tasks %>%
+  split(.$pipeline)
+
+summary_tasks$Group <- factor(summary_tasks$group,
+                              levels = unique(seqera_platform_logs@group))
+
+## If a pipeline was run more than once, we modify how we plot the barplots 
+if(n_runs_max > 1){
+  instance_type_plot <- ggplot(summary_tasks, aes(x = paste(group,run_id,sep=" : "), y = n,
+                                                fill = machineType,
+                                                text = paste("Tasks: ",n,"\n",
+                                                             "Instance type: ",machineType,
+                                                             sep="")))
+  x_axis_mod <- theme(axis.text.x = element_text(angle = 45, hjust = 1))
+}else{
+  instance_type_plot <- ggplot(summary_tasks, aes(x = group, y = n,
+                                                fill = machineType,
+                                                text = paste("Tasks: ",n,"\n",
+                                                             "Instance type: ",machineType,
+                                                             sep="")))
+  x_axis_mod <- theme(axis.text.x = element_text(angle = 90, hjust = 1))
+}
+
+names(instance_palette) <- unique(summary_tasks$machineType)
+instance_type_plot <- instance_type_plot +
+  geom_bar(stat = "identity", color = "black", position = "stack") +
+  labs(
+    x = "",
+    y = "Number of tasks",
+    fill = "group"
+  ) +
+  seqera_light_theme() +
+  theme(strip.text = element_text(size = 12),
+        axis.title.x = element_text(margin = margin(t = 20, r = 0, b = 0, l = 0)),
+        panel.spacing.y = unit(2, "line"),
+        plot.margin = unit(c(1, 1, 1, 1), "cm"),
+        legend.position = "right",
+        legend.title=element_text(face = "bold")
+        ) +
+  facet_wrap(~ pipeline, scales = "free_y", ncol = 2) +
+  scale_fill_manual(values = instance_palette) +
+  scale_y_continuous(limits = expand_x_limits,breaks = scales::pretty_breaks(n = 5), labels = function(x) ifelse(x == floor(x), x, NA)) +
+  x_axis_mod
+
+ggplotly(instance_type_plot, tooltip="text") %>%
+  set_ggplotly_font() %>%
+  plotly::layout(
+    hovermode='x',
+    margin = list(r = 200),  # Increase the right margin
+    legend = list(
+      x = 1.02,  # Position the legend outside the plot area
+      y = 1,
+      orientation = "v",
+      font = list(size = 14)  # Adjust the font size if needed
+    )
+  ) %>%
+  htmlwidgets::onRender("
+    function(el, x) {
+      var legendItems = el.querySelectorAll('.legendtext');
+      legendItems.forEach(function(item) {
+        item.style.width = '100px';  // Adjust the width as needed
+        item.style.whiteSpace = 'normal';  // Allow wrapping
+      });
+    }
+  ")
+```
+
+## Task metrics
+
+This section provides a comparison and overview between staging and run times for tasks for each pipeline across these groups: `r groups_string`.
+
+The different times for tasks are defined as follows:
+
+-   **Wait time**: The time taken from submission to the start of the task.
+-   **Staging time**: The time taken to stage and unstage the task before and after execution.
+-   **Real time**: The time taken to execute the task.
+-   **Task duration**: The elapsed time from task start to task completion, which corresponds to staging time plus real time.
+
+For more detailed explanation of metrics shown in the table below the task plots, please see the [Nextflow reports documentation](https://www.nextflow.io/docs/latest/tracing.html).
+
+::: {.callout-tip .benchmark_callouts title="Plot interaction" collapse="true"}
+-   Single-click on any point to highlight the specific process in the table below.
+-   Double-click on any whitespace in the plot to unselect a point.
+:::
+
+```{r, results='asis'}
+#| label: task-level-plots
+#| fig-width: 12
+#| fig-height: 12
+#| warning: false
+
+## alpha value for the background color of the table
+row_alpha_value <- 0.15
+point_alpha <- 1
+point_size <- 2
+
+for(pipe in unique(task_data$pipeline)){
+  
+  #### Task staging and run times
+  pipe_parsed <- gsub("/","_",pipe)
+  cat(paste0("### ",pipe,paste0("{#sec-task-",pipe_parsed,"}"), " \n"))
+  
+  group1 <- as.character(unique(task_data$group)[1])
+  group2 <- as.character(unique(task_data$group)[2])
+  
+  #### Cost plots
+  if(grepl("cost",profile)){
+    
+    # cat(paste('The plots in this section show the cost distribution of tasks per process between the two groups. Tasks are grouped by processes on the x axis, so to show which process has a large cost spread across tasks and how this differs between groups. \n\n',sep=""))
+    
+    pipe_task_data_cost<- task_data %>%
+      subset(pipeline == pipe) %>%
+      select(run_id,pipeline,group,process,name,name_short,hash,runtime_mins,waittime_mins,staging_time_mins,realtime_mins)
+    pipe_task_data_cost$hash <- gsub("/","",pipe_task_data_cost$hash)
+    
+    cost_table_pipe <- cost_table %>%
+      subset(pipeline == pipe)
+    
+    cost_data_pipe_task <- full_join(cost_table_pipe,pipe_task_data_cost,by=c("run_id","pipeline","group","process","hash")) 
+    cost_data_pipe_task <- cost_data_pipe_task %>%
+      mutate(process_short = paste(str_extract(process, "[^:]+$"),sep=" - "))
+    
+    ## Sort processes based on most variation in cost between groups
+    process_sum_cost <- cost_data_pipe_task %>%
+      group_by(process_short,group) %>%
+      summarise(sum_cost = mean(cost)) %>%
+      ungroup() %>%
+      group_by(process_short) %>%
+      summarise(cost_sd = sd(sum_cost)) %>%
+      ungroup() %>%
+      arrange(desc(cost_sd))
+    
+    cost_data_pipe_task$process_short <- factor(cost_data_pipe_task$process_short, levels = process_sum_cost$process_short)
+  
+    shared_cost_data_pipe <- SharedData$new(cost_data_pipe_task, key = ~name, group = pipe)
+  
+    cost_task_time <- ggplot(shared_cost_data_pipe,
+                             aes(x = process_short,
+                                 y = cost,
+                                 text = paste("Task name: ",name,"\n",
+                                              "Task cost:",cost,sep=""))) +
+      ## Add a boxplot with color = group that is dodged by group
+      geom_boxplot(aes(color = group)) +
+      geom_point(aes(color = group),position = position_dodge(width = 0.9), alpha = 1) +
+      scale_color_manual(values = groups_color_palette) +
+      labs(x = "Processes",
+           y = "Task cost ($)",
+           title = "Per task cost") +
+      seqera_light_theme() +
+      theme(plot.margin = unit(c(t = 1, r =1, b = 1.3, l = 1), "cm")
+            ) +
+      theme(axis.text.x = element_blank(),
+            plot.title = element_text(size = plot_title_size)) +
+      guides(shape = 21)
+    
+      cost_task_time_plotly <- ggplotly(cost_task_time, tooltip = "text")
+      
+      hideOutliers <- function(x) {  
+      if (x$hoverinfo == 'y') {  
+        x$marker = list(opacity = 0)
+        x$hoverinfo = NA    
+        }  
+      return(x)  
+    }
+
+    n_groups <- length(unique(cost_data_pipe_task$group))
+    cost_task_time_plotly[["x"]][["data"]] <- map(cost_task_time_plotly[["x"]][["data"]], ~ hideOutliers(.))
+    
+    ## Fix ggplotly legend
+    cost_task_time_plotly <- cost_task_time_plotly %>% style(cost_task_time_plotly,showlegend = FALSE, traces = 1:n_groups)
+    cost_task_time_plotly <- cost_task_time_plotly %>% style(cost_task_time_plotly,showlegend = TRUE, traces = (n_groups+1):(n_groups*2))
+    
+    ## Make boxplot not interactive
+    cost_task_time_plotly <- cost_task_time_plotly %>% style(cost_task_time_plotly, hoverinfo = "none", traces = 1:n_groups)
+      
+        
+      print(htmltools::tagList(
+         cost_task_time_plotly %>%
+          layout(hoverlabel = list(align = "left"),
+                 boxmode = "group") %>%
+          highlight(on = "plotly_click", off = "plotly_doubleclick", opacityDim = 0.1) %>%
+          set_ggplotly_font() %>% 
+          toWebGL()
+        )
+      )
+    
+    cost_data_pipe_task_table <- cost_data_pipe_task %>%
+      select(group,run_id,hash,name,cost,used_cost,unused_cost)
+    
+    ## Set order of Groups
+    cost_data_pipe_task_table$group <- factor(cost_data_pipe_task_table$group,
+                                              levels = unique(seqera_platform_logs@group))
+    
+    shared_data_cost_table <- SharedData$new(cost_data_pipe_task_table, key = ~name, group = pipe)
+    
+    rgba_colors <- sapply(groups_color_palette, hex_to_rgba, alpha = row_alpha_value)[1:length(unique(cost_data_pipe_task_table$group))]
+    pipe_cost_table <- div(class = "scrollable-table",
+                             datatable(shared_data_cost_table,
+                                   class = 'nowrap',
+                                   escape = FALSE,
+                                   colnames = c("Group" = "group", ## Order of colnames is important here!!!
+                                                "Run ID" = "run_id",
+                                                "Task<br/>hash" = "hash",
+                                                "Compute cost" = "cost",
+                                                "Used compute cost" = "used_cost",
+                                                "Unused compute cost" = "unused_cost",
+                                                "Task name" = "name"),
+                                   selection="none",
+                                   rownames= FALSE,
+                                   options = list(autoWidth = FALSE,
+                                                  language = list(search = 'Filter:'),
+                                                  pageLength = 5,
+                                                  order = list(list(2, 'asc')),
+                                                  initComplete = JS(
+                                                    "function(settings, json) {",
+                                                    "$('table').css({'font-size': '17px'});",
+                                                    "}"
+                                                  ))
+                                   ) %>%
+        formatStyle(
+          'Group',
+          target = 'row',
+          backgroundColor = styleEqual(
+            names(rgba_colors),
+            rgba_colors
+            )
+        )
+      )
+  
+      print(htmltools::tagList(
+        tags$style(HTML("
+      .dataTable thead th {
+        background-color: #160f26 !important;
+        color: white !important;
+        text-align: left !important;
+        white-space: nowrap;
+      }
+      .dataTable tbody td {
+        text-align: left !important;
+        white-space: nowrap;
+      }
+      .scrollable-table {
+        width: 100%;
+        overflow-x: auto;
+      }
+      /* Style for the download button */
+      .dt-button {
+        background-color: #160F26 !important;
+        border: none !important;
+        color: white !important;
+        padding: 10px 10px !important;
+        text-align: center !important;
+        text-decoration: none !important;
+        display: inline-block !important;
+        font-size: 17px !important;
+        margin: 4px 2px !important;
+        cursor: pointer !important;
+        border-radius: 5px !important;
+      }
+      .dt-button:hover {
+        background-color: #0DC09D !important;
+      }
+    ")
+        ),
+      pipe_cost_table))
+  }
+  
+  pipe_task_data_plot <- task_data %>%
+    subset(pipeline == pipe)
+
+  
+  ####
+  #### Code chunk that will be run if comparing 2 groups with 1 run each (Quicklaunches)
+  ####
+  if (benchmark_scenario == "2groups_1run") {
+    group1 <- as.character(unique(pipe_task_data_plot$group)[1])
+    group2 <- as.character(unique(pipe_task_data_plot$group)[2])
+    pipe_tasks_data <- task_data %>%
+      subset(pipeline == pipe)
+    
+    ## Calculate the staging difference between the two groups
+    pipe_staging_time <- pipe_tasks_data %>%
+      select(pipeline,group,process,process_short,name,name_short,staging_time_mins) %>%
+      group_by(pipeline,process,process_short,name,name_short) %>%
+      pivot_wider(names_from = group, values_from = staging_time_mins,values_fn = sum) %>%
+      mutate("staging_diff_min" = !!sym(group1) - !!sym(group2)) %>%
+      ungroup() %>%
+      arrange(desc(staging_diff_min))
+    
+    ## Calculate the realtime difference between the two groups
+    pipe_tasks_realtime <- pipe_tasks_data %>%
+      select(pipeline,group,process,process_short,name,name_short,realtime_mins) %>%
+      group_by(pipeline,process,process_short,name,name_short) %>%
+      pivot_wider(names_from = group, values_from = realtime_mins,values_fn = sum) %>%
+      mutate("realtime_diff_min" = !!sym(group1) - !!sym(group2)) %>%
+      ungroup() %>%
+      arrange(desc(realtime_diff_min))
+    
+    shared_data_staging <- SharedData$new(pipe_staging_time, key = ~name, group = pipe)
+    shared_data_realtimes <- SharedData$new(pipe_tasks_realtime,   key = ~name, group = pipe)
+    
+    ## Realtime task plot
+    pipe_task_staging_plot <- ggplot(shared_data_staging, 
+           aes(x = get(group1), 
+               y = get(group2),
+               text = paste("Task name: ",name_short,"\n",
+                             group1, " : ",sprintf("%02d:%02d:%02d", floor(get(group1) / 60), floor(get(group1) %% 60), round((get(group1) %% 1) * 60)),"\n",
+                             group2, " : ",sprintf("%02d:%02d:%02d", floor(get(group2) / 60), floor(get(group2) %% 60), round((get(group2) %% 1) * 60)),"\n",
+                                                        sep=""),
+               group = staging_diff_min)) +
+    geom_point(size = point_size, alpha = point_alpha, color = "#160F26") +
+    geom_abline(intercept = 0, slope = 1, linetype = "dashed") +
+    labs(
+      x = group1,
+      y = group2,
+      color = "Pipeline",
+      title = "Staging time (minutes)"
+    ) +
+    seqera_light_theme() +
+    theme(legend.position = "none",
+          plot.margin = unit(c(t = 1, r =1, b = 1.3, l = 1), "cm"),
+          plot.title = element_text(size = plot_title_size),
+    )
+    
+    ## Realtime task plot
+    pipe_task_realtime_plot <- ggplot(shared_data_realtimes, 
+           aes(x = get(group1), 
+               y = get(group2),
+               text = paste("Task name: ",name_short,"\n",
+                             group1, " : ",sprintf("%02d:%02d:%02d", floor(get(group1) / 60), floor(get(group1) %% 60), round((get(group1) %% 1) * 60)),"\n",
+                             group2, " : ",sprintf("%02d:%02d:%02d", floor(get(group2) / 60), floor(get(group2) %% 60), round((get(group2) %% 1) * 60)),"\n",
+                                                        sep=""),
+               group = realtime_diff_min)) +
+    geom_point(size = 2, alpha = 1, color = "#160F26") +
+    geom_abline(intercept = 0, slope = 1, linetype = "dashed") +
+    labs(
+      x = group1,
+      y = group2,
+      color = "Pipeline",
+      title = "Real time (minutes)"
+    ) + 
+    seqera_light_theme() +
+    theme(legend.position = "none",
+          plot.margin = unit(c(t = 1, r =1, b = 1.3, l = 1), "cm"),
+          plot.title = element_text(size = plot_title_size)
+    )
+
+    print(htmltools::tagList(
+        div(style = "display: inline-block; width: 49%;", 
+            ggplotly(pipe_task_staging_plot, tooltip = "text") %>% 
+              layout(hoverlabel = list(align = "left")) %>% 
+              highlight(on = "plotly_click", off = "plotly_doubleclick", opacityDim = 0.05) %>% 
+              set_ggplotly_font()) %>% toWebGL(),
+        div(style = "display: inline-block; width: 49%;", 
+            ggplotly(pipe_task_realtime_plot, tooltip = "text") %>% 
+              layout(hoverlabel = list(align = "left")) %>% 
+              highlight(on = "plotly_click", off = "plotly_doubleclick", opacityDim = 0.05) %>% 
+              set_ggplotly_font()) %>% toWebGL()
+        )
+      )
+
+  
+  ####
+  #### More than 2 groups to compare or multiple pipeline runs for the same pipeline
+  ####
+  }else {
+
+    shared_data_tasks_plot <- SharedData$new(pipe_task_data_plot, key = ~name, group = pipe)
+
+    ## If a pipeline was run more than once, we modify how we plot the points
+    if(n_runs_max > 1){
+      task_points_layer <- geom_point(aes(color = group), 
+                                      size = point_size, 
+                                      alpha = point_alpha)
+    }else{
+      task_points_layer <- geom_point(aes(color = group), 
+               size = point_size,
+               alpha = point_alpha)
+    }
+    
+    runtime_vs_realtime_plot <- ggplot(shared_data_tasks_plot,
+                                       aes(x = realtime_mins,
+                                           y = staging_time_mins, 
+                                           text = paste("Task name: ",name_short,"\n",
+                                                        "run_id :",run_id,"\n",
+                                                        "Submission time: ",waittime,"\n",
+                                                        "Staging time: ",staging_time,"\n",
+                                                        "Execution time: ",real_time,
+                                                        sep=""))
+                                       ) +
+    task_points_layer +
+    labs(
+      x = "Task real time (minutes)",
+      y = "Task staging time (minutes)",
+      title = "Task staging and real times",
+      color = "group"
+    ) +
+      seqera_light_theme() + 
+      scale_color_manual(values = groups_color_palette)  +
+      theme(plot.title = element_text(size = plot_title_size))
+    
+    print(htmltools::tagList(
+    ggplotly(runtime_vs_realtime_plot, tooltip = "text") %>% 
+      layout(hoverlabel = list(align = "left")) %>% highlight(on = "plotly_click", off = "plotly_doubleclick") %>%
+      set_ggplotly_font() %>% toWebGL()
+    )
+  )
+    
+  } ## End of if-else for multi-group
+
+  ## Select only columns we will use in the table
+  pipe_task_data_table <- pipe_task_data_plot %>%
+    select(group,run_id,name_short,hash,
+           waittime,real_time,staging_time,
+           cpus,memory,pcpu,pmem,rss,volCtxt,invCtxt,readBytes,writeBytes,
+           executor,cloudZone,machineType,name,status)
+  
+  if(grepl("cost",profile)){
+  ## Add accurate cost from cost_data_pipe_task_table
+    accurate_task_cost <- cost_data_pipe_task_table %>%
+      select(group,run_id,hash,cost) %>%
+      mutate(hash = paste0(substr(hash, 1, 2), "/", substr(hash, 3, nchar(hash))))
+    
+    pipe_task_data_table <- full_join(pipe_task_data_table,accurate_task_cost,
+                                      by = c("group","run_id","hash"))
+  }
+  
+  ## Tasks table
+  shared_data_tasks_table <- SharedData$new(pipe_task_data_table, key = ~name, group = pipe)
+  font.size <- "12"
+  rgba_colors <- sapply(groups_color_palette, hex_to_rgba, alpha = row_alpha_value)[1:length(unique(pipe_task_data_table$group))]
+  
+  # Define base column names that are common to both scenarios
+  base_col_names <- c(
+    "Group" = "group",
+    "Run ID" = "run_id", 
+    "Task<br/>hash" = "hash", 
+    "Task name short" = "name_short",
+    "Executor" = "executor",
+    "Cloud<br/>zone" = "cloudZone",
+    "Instance type" = "machineType",
+    "Wait<br/>time" = "waittime",
+    "Staging<br/>time" = "staging_time",
+    "Real<br/>time" = "real_time",
+    "Requested<br/>CPUs" = "cpus",
+    "Requested memory<br/>(GiB)" = "memory",
+    "Observed CPU<br/>(%)" = "pcpu",
+    "Observed memory<br/>(%)" = "pmem",
+    "Peak RSS<br/>(GiB)" = "rss",
+    "Read<br/>bytes" = "readBytes",
+    "Write<br/>bytes" = "writeBytes",
+    "VolCtxt" = "volCtxt",
+    "InvCtxt" = "invCtxt",
+    "Task name" = "name",
+    "Status" = "status"
+  )
+  
+  # Add cost column if it exists
+  col_names <- if("cost" %in% colnames(pipe_task_data_table)) {
+    c(base_col_names[1:10], "Cost" = "cost", base_col_names[11:21])
+  } else {
+    base_col_names
+  }
+  
+  # We need to select the actual column names from the data frame, not the display names
+  pipe_task_data_table_filtered <- pipe_task_data_table %>%
+    select(all_of(unname(col_names)))
+  
+  # Create a new SharedData object with the filtered data
+  shared_data_tasks_table_filtered <- SharedData$new(pipe_task_data_table_filtered, key = ~name, group = pipe)
+  
+  # Create the datatable
+  pipe_task_table <- div(
+    class = "scrollable-table",
+    datatable(
+      shared_data_tasks_table_filtered,
+      class = 'display',
+      extensions = c('Buttons'),
+      escape = FALSE,
+      colnames = col_names,
+      selection = "none",
+      rownames = FALSE,
+      options = list(
+        autoWidth = FALSE,
+        language = list(search = 'Filter:'),
+        pageLength = 10,
+        order = list(list(2, 'asc')),
+        dom = 'Bfrtip',
+        buttons = list(
+          list(
+            extend = 'csv',
+            text = 'Download task table as CSV',
+            filename = 'task_table'
+          )
+        ),
+        initComplete = JS(
+          "function(settings, json) {",
+          "$('table').css({'font-size': '17px'});",
+          "}"
+        )
+      )
+    ) %>%
+    formatStyle(
+      'Group',
+      target = 'row',
+      backgroundColor = styleEqual(
+        names(rgba_colors),
+        rgba_colors
+      )
+    )
+  )
+  
+  print(htmltools::tagList(
+    tags$style(HTML("
+  .dataTable thead th {
+    background-color: #160f26 !important;
+    color: white !important;
+    text-align: left !important;
+    white-space: nowrap;
+  }
+  .dataTable tbody td {
+    text-align: left !important;
+    white-space: nowrap;
+  }
+  .scrollable-table {
+    width: 100%;
+    overflow-x: auto;
+  }
+  /* Style for the download button */
+  .dt-button {
+    background-color: #160F26 !important;
+    border: none !important;
+    color: white !important;
+    padding: 10px 10px !important;
+    text-align: center !important;
+    text-decoration: none !important;
+    display: inline-block !important;
+    font-size: 17px !important;
+    margin: 4px 2px !important;
+    cursor: pointer !important;
+    border-radius: 5px !important;
+  }
+  .dt-button:hover {
+    background-color: #0DC09D !important;
+  }
+")
+    ),
+  pipe_task_table))
+  
+  cat("\n\n")
+  cat(sprintf('<div style="margin-bottom: 40px;"></div>'))
+}
+```

--- a/modules/local/benchmark_report/overrides/render_benchmark_report.R
+++ b/modules/local/benchmark_report/overrides/render_benchmark_report.R
@@ -1,0 +1,516 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages({
+  library(data.table)
+  library(dplyr)
+  library(jsonlite)
+  library(lubridate)
+  library(stringr)
+  library(tidyr)
+})
+
+parse_args <- function(args) {
+  parsed <- list(
+    log_csv = NULL,
+    output = "benchmark_report.html",
+    aws_cost = NULL,
+    remove_failed_tasks = FALSE
+  )
+
+  i <- 1
+  while (i <= length(args)) {
+    arg <- args[[i]]
+    if (!startsWith(arg, "--")) {
+      stop(sprintf("Unexpected positional argument: %s", arg))
+    }
+
+    key <- sub("^--", "", arg)
+    if (key %in% c("remove_failed_tasks", "remove-failed-tasks")) {
+      parsed$remove_failed_tasks <- TRUE
+      i <- i + 1
+      next
+    }
+
+    if (i == length(args)) {
+      stop(sprintf("Missing value for --%s", key))
+    }
+
+    value <- args[[i + 1]]
+    switch(
+      key,
+      "log_csv" = parsed$log_csv <- value,
+      "log-csv" = parsed$log_csv <- value,
+      "output" = parsed$output <- value,
+      "aws_cost" = parsed$aws_cost <- value,
+      "aws-cost" = parsed$aws_cost <- value,
+      stop(sprintf("Unknown argument: --%s", key))
+    )
+    i <- i + 2
+  }
+
+  if (is.null(parsed$log_csv) || parsed$log_csv == "") {
+    stop("--log_csv is required")
+  }
+
+  parsed
+}
+
+remove_prefixes <- function(names) {
+  prefixes <- c(
+    "service_info\\.",
+    "workflow_launch\\.",
+    "workflow_load\\.",
+    "workflow_metadata\\.",
+    "workflow\\."
+  )
+  pattern <- paste0("^(", paste(prefixes, collapse = "|"), ")")
+  gsub(pattern, "", names)
+}
+
+first_present <- function(df, candidates, default = NA) {
+  for (candidate in candidates) {
+    if (candidate %in% names(df)) {
+      return(df[[candidate]])
+    }
+  }
+  rep(default, nrow(df))
+}
+
+clean_scalar_chr <- function(x) {
+  x <- as.character(x)
+  x[is.na(x)] <- ""
+  x
+}
+
+safe_sd <- function(x) {
+  if (sum(!is.na(x)) <= 1) {
+    return(NA_real_)
+  }
+  sd(x, na.rm = TRUE)
+}
+
+build_cost_table <- function(task_data, merged_logs, aws_cost = NULL, remove_failed_tasks = FALSE) {
+  accurate_task_costs <- data.frame()
+  run_group_lookup <- merged_logs %>%
+    distinct(run_id, group)
+
+  if (!"group" %in% names(task_data)) {
+    task_data <- task_data %>%
+      left_join(run_group_lookup, by = "run_id")
+  } else {
+    task_data <- task_data %>%
+      left_join(run_group_lookup, by = "run_id", suffix = c("", "_run")) %>%
+      mutate(group = coalesce(na_if(as.character(group), ""), as.character(group_run))) %>%
+      select(-any_of("group_run"))
+  }
+
+  if (!is.null(aws_cost) && !is.na(aws_cost) && aws_cost != "") {
+    suppressPackageStartupMessages(library(arrow))
+
+    core_aws_cur_cols <- c(
+      "identity_line_item_id",
+      "line_item_usage_type",
+      "split_line_item_split_cost",
+      "split_line_item_unused_cost",
+      "line_item_blended_cost",
+      "resource_tags"
+    )
+
+    aws_cost_table <- read_parquet(aws_cost)
+    if ("resource_tags" %in% names(aws_cost_table)) {
+      aws_cost_table <- reformat_cur2_0(
+        aws_cost_table,
+        run_ids = unique(merged_logs$run_id),
+        run_id_col = "resource_tags_user_unique_run_id"
+      )
+      core_aws_cur_cols <- core_aws_cur_cols[!core_aws_cur_cols %in% "resource_tags"]
+    }
+
+    required_tags <- c(
+      "resource_tags_user_unique_run_id",
+      "resource_tags_user_pipeline_process",
+      "resource_tags_user_task_hash"
+    )
+    core_aws_cur_cols <- c(core_aws_cur_cols, required_tags)
+
+    accurate_task_costs <- aws_cost_table %>%
+      select(all_of(core_aws_cur_cols)) %>%
+      mutate(
+        cost = split_line_item_split_cost + split_line_item_unused_cost,
+        used_cost = split_line_item_split_cost,
+        unused_cost = split_line_item_unused_cost,
+        run_id = resource_tags_user_unique_run_id,
+        process = resource_tags_user_pipeline_process,
+        hash = substr(resource_tags_user_task_hash, 1, 8)
+      ) %>%
+      left_join(merged_logs %>% select(run_id, group, pipeline), by = "run_id") %>%
+      group_by(run_id, pipeline, group, process, hash) %>%
+      summarise(
+        cost = sum(cost, na.rm = TRUE),
+        used_cost = sum(used_cost, na.rm = TRUE),
+        unused_cost = sum(unused_cost, na.rm = TRUE),
+        .groups = "drop"
+      )
+  }
+
+  if ("cost" %in% names(task_data)) {
+    estim_task_costs <- task_data %>%
+      select(run_id, pipeline, group, process, cost, hash) %>%
+      mutate(hash = gsub("/", "", hash))
+  } else {
+    estim_task_costs <- task_data %>%
+      select(run_id, pipeline, group, process, hash) %>%
+      mutate(
+        hash = gsub("/", "", hash),
+        cost = NA_real_
+      )
+  }
+
+  cost_table <- if (nrow(accurate_task_costs) > 0) accurate_task_costs else estim_task_costs
+
+  if (remove_failed_tasks && nrow(cost_table) > 0) {
+    task_status <- task_data %>%
+      transmute(run_id, hash = gsub("/", "", hash), status)
+    cost_table <- cost_table %>%
+      left_join(task_status, by = c("run_id", "hash")) %>%
+      filter(status == "COMPLETED") %>%
+      select(-status)
+  }
+
+  cost_table
+}
+
+args <- parse_args(commandArgs(trailingOnly = TRUE))
+
+source("benchmark_functions.R")
+for (file in list.files("functions", pattern = "\\.R$", full.names = TRUE)) {
+  source(file)
+}
+
+seqera_platform_logs <- createSeqeraPlatformRunCollectionFromSamplesheet(args$log_csv)
+
+merged_logs <- getWorkflowData(seqera_platform_logs, "run_logs")
+colnames(merged_logs) <- remove_prefixes(colnames(merged_logs))
+
+merged_logs <- merged_logs %>%
+  mutate(
+    pipeline = clean_scalar_chr(first_present(., c("repository", "pipeline"))),
+    cost = suppressWarnings(as.numeric(first_present(., "cost", NA_real_))),
+    cpuTime = suppressWarnings(as.numeric(first_present(., "cpuTime", NA_real_))),
+    duration = suppressWarnings(as.numeric(first_present(., "duration", NA_real_))),
+    readBytes = suppressWarnings(as.numeric(first_present(., "readBytes", NA_real_))),
+    writeBytes = suppressWarnings(as.numeric(first_present(., "writeBytes", NA_real_))),
+    cpuEfficiency = suppressWarnings(as.numeric(first_present(., "cpuEfficiency", NA_real_))),
+    memoryEfficiency = suppressWarnings(as.numeric(first_present(., "memoryEfficiency", NA_real_))),
+    succeeded = coalesce(
+      suppressWarnings(as.numeric(first_present(., "succeeded", NA_real_))),
+      suppressWarnings(as.numeric(first_present(., "stats.succeedCount", NA_real_))),
+      suppressWarnings(as.numeric(first_present(., "succeedCount", NA_real_)))
+    ),
+    failed = coalesce(
+      suppressWarnings(as.numeric(first_present(., "failed", NA_real_))),
+      suppressWarnings(as.numeric(first_present(., "stats.failedCount", NA_real_))),
+      suppressWarnings(as.numeric(first_present(., "failedCount", NA_real_)))
+    ),
+    cached = coalesce(
+      suppressWarnings(as.numeric(first_present(., "cached", NA_real_))),
+      suppressWarnings(as.numeric(first_present(., "stats.cachedCount", NA_real_))),
+      suppressWarnings(as.numeric(first_present(., "cachedCount", NA_real_))),
+      0
+    )
+  ) %>%
+  mutate(
+    cost = round(cost, 2),
+    cpuTime = round(cpuTime / 1000 / 3600, 1),
+    readBytes = round(readBytes / (1024^3), 2),
+    writeBytes = round(writeBytes / (1024^3), 2),
+    cpuEfficiency = round(cpuEfficiency, 2),
+    memoryEfficiency = round(memoryEfficiency, 2)
+  )
+
+run_id_pipeline <- merged_logs %>% select(run_id, pipeline, group)
+
+task_data <- getWorkflowData(seqera_platform_logs, "workflow_tasks") %>%
+  left_join(run_id_pipeline, by = "run_id") %>%
+  mutate(
+    submit = as.POSIXct(submit, format = "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC"),
+    start = as.POSIXct(start, format = "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC"),
+    complete = as.POSIXct(complete, format = "%Y-%m-%dT%H:%M:%OSZ", tz = "UTC"),
+    runtime_seconds = as.numeric(difftime(complete, start, units = "secs")),
+    runtime_mins = as.numeric(difftime(complete, start, units = "mins")),
+    waittime_mins = as.numeric(difftime(start, submit, units = "mins")),
+    realtime_mins = as.numeric(realtime) / 1000 / 60,
+    duration_mins = as.numeric(duration) / 1000 / 60,
+    staging_time_mins = pmax(runtime_mins - realtime_mins, 0),
+    process_short = str_extract(process, "[^:]+$"),
+    requested_memory_gib_raw = memory / (1024^3),
+    rss_gib_raw = rss / (1024^3),
+    memory = round(requested_memory_gib_raw, 2),
+    rss = round(rss_gib_raw, 2)
+  ) %>%
+  mutate(
+    waittime = sprintf("%02d:%02d:%02d", floor(waittime_mins / 60), floor(waittime_mins %% 60), round((waittime_mins %% 1) * 60)),
+    staging_time = sprintf("%02d:%02d:%02d", floor(staging_time_mins / 60), floor(staging_time_mins %% 60), round((staging_time_mins %% 1) * 60)),
+    real_time = sprintf("%02d:%02d:%02d", floor(realtime_mins / 60), floor(realtime_mins %% 60), round((realtime_mins %% 1) * 60))
+  )
+
+task_group_lookup <- merged_logs %>% select(run_id, group) %>% distinct()
+if (!"group" %in% names(task_data)) {
+  task_data <- task_data %>%
+    left_join(task_group_lookup, by = "run_id") %>%
+    mutate(group = clean_scalar_chr(coalesce(as.character(group), "")))
+} else {
+  task_data <- task_data %>%
+    left_join(task_group_lookup, by = "run_id", suffix = c("", "_run")) %>%
+    mutate(group = clean_scalar_chr(coalesce(na_if(as.character(group), ""), as.character(group_run), ""))) %>%
+    select(-any_of("group_run"))
+}
+
+if (args$remove_failed_tasks) {
+  task_data <- task_data %>% filter(status == "COMPLETED")
+}
+
+task_run_metrics <- compute_task_run_metrics(task_data)
+merged_logs <- merged_logs %>%
+  left_join(task_run_metrics, by = c("run_id", "pipeline")) %>%
+  mutate(
+    cpuTime = coalesce(round(requestedCpuH, 1), cpuTime),
+    cpuEfficiency = coalesce(round(cpuEfficiency_calc, 2), cpuEfficiency),
+    memoryEfficiency = coalesce(round(memoryEfficiency_calc, 2), memoryEfficiency),
+    task_runtime_ms = coalesce(task_runtime_ms, duration)
+  ) %>%
+  select(-cpuEfficiency_calc, -memoryEfficiency_calc)
+
+machine_data <- getWorkflowData(seqera_platform_logs, "machine_data")
+if (nrow(machine_data) > 0) {
+  machine_run_metrics <- summarise_machine_metrics(machine_data, run_id_pipeline, task_run_metrics)
+  merged_logs <- merged_logs %>% left_join(machine_run_metrics, by = c("run_id", "pipeline"))
+}
+
+cost_table <- build_cost_table(
+  task_data = task_data,
+  merged_logs = merged_logs,
+  aws_cost = args$aws_cost,
+  remove_failed_tasks = args$remove_failed_tasks
+)
+
+if (!"used_cost" %in% names(cost_table)) {
+  cost_table$used_cost <- NA_real_
+}
+if (!"unused_cost" %in% names(cost_table)) {
+  cost_table$unused_cost <- NA_real_
+}
+
+if (!is.null(args$aws_cost) && !is.na(args$aws_cost) && args$aws_cost != "") {
+  cost_lookup <- cost_table %>%
+    rename(
+      hash_clean = hash,
+      cost_report = cost,
+      used_cost_report = used_cost,
+      unused_cost_report = unused_cost
+    )
+
+  task_data_aug <- task_data %>%
+    mutate(hash_clean = gsub("/", "", hash)) %>%
+    left_join(cost_lookup, by = c("run_id", "pipeline", "group", "process", "hash_clean")) %>%
+    mutate(
+      cost = coalesce(cost_report, suppressWarnings(as.numeric(cost))),
+      used_cost = used_cost_report,
+      unused_cost = unused_cost_report
+    )
+} else {
+  task_data_aug <- task_data %>%
+    mutate(
+      hash_clean = gsub("/", "", hash),
+      cost = suppressWarnings(as.numeric(cost)),
+      used_cost = NA_real_,
+      unused_cost = NA_real_
+    )
+}
+
+has_used_cost <- "used_cost" %in% names(task_data_aug)
+has_unused_cost <- "unused_cost" %in% names(task_data_aug)
+
+run_costs <- task_data_aug %>%
+  group_by(run_id, group) %>%
+  summarise(
+    cost = if (all(is.na(cost))) NA_real_ else round(sum(cost, na.rm = TRUE), 2),
+    used_cost = if (has_used_cost && !all(is.na(used_cost))) round(sum(used_cost, na.rm = TRUE), 2) else NA_real_,
+    unused_cost = if (has_unused_cost && !all(is.na(unused_cost))) round(sum(unused_cost, na.rm = TRUE), 2) else NA_real_,
+    .groups = "drop"
+  )
+
+workspace_values <- clean_scalar_chr(first_present(merged_logs, c("workspaceFullName", "workspaceName", "workspaceId"), ""))
+platform_urls <- clean_scalar_chr(first_present(merged_logs, c("runUrl"), ""))
+
+benchmark_overview <- merged_logs %>%
+  transmute(
+    pipeline = clean_scalar_chr(pipeline),
+    group = clean_scalar_chr(group),
+    run_id = clean_scalar_chr(run_id),
+    workspace = workspace_values,
+    platform_url = platform_urls
+  )
+
+run_strategy <- merged_logs %>%
+  distinct(run_id, pipeline, group)
+run_strategy <- bind_cols(run_strategy, detect_scheduler_profile(run_strategy$group))
+
+run_summary <- merged_logs %>%
+  left_join(run_strategy, by = c("run_id", "pipeline", "group")) %>%
+  transmute(
+    pipeline = clean_scalar_chr(pipeline),
+    group = clean_scalar_chr(group),
+    run_id = clean_scalar_chr(run_id),
+    username = clean_scalar_chr(first_present(., c("userName", "username"), "")),
+    Version = clean_scalar_chr(first_present(., c("workflow_revision", "revision", "Version"), "")),
+    Nextflow_version = clean_scalar_chr(first_present(., c("nextflow.version", "Nextflow_version"), "")),
+    platform_version = clean_scalar_chr(first_present(., c("platform_version", "version"), "")),
+    succeedCount = suppressWarnings(as.numeric(first_present(., c("stats.succeedCount", "succeedCount", "succeeded"), 0))),
+    failedCount = suppressWarnings(as.numeric(first_present(., c("stats.failedCount", "failedCount", "failed"), 0))),
+    cachedCount = suppressWarnings(as.numeric(first_present(., c("stats.cachedCount", "cachedCount", "cached"), 0))),
+    executor = clean_scalar_chr(first_present(., c("executors", "executor"), "")),
+    region = clean_scalar_chr(first_present(., c("computeEnv.config.region", "region"), "")),
+    fusion_enabled = as.logical(first_present(., c("computeEnv.config.fusion2Enabled", "fusion_enabled"), FALSE)),
+    wave_enabled = as.logical(first_present(., c("computeEnv.config.waveEnabled", "wave_enabled"), FALSE)),
+    container_engine = clean_scalar_chr(first_present(., c("containerEngine", "container_engine"), "")),
+    scheduler_mode = clean_scalar_chr(first_present(., c("scheduler_mode", "scheduler_mode.x", "scheduler_mode.y"), "")),
+    task_rightsizing = clean_scalar_chr(first_present(., c("rightsizing_mode", "rightsizing_mode.x", "rightsizing_mode.y"), "")),
+    packing = dplyr::if_else(as.logical(first_present(., c("packing_enabled", "packing_enabled.x", "packing_enabled.y"), FALSE)), "Yes", "No"),
+    vm_provisioning = clean_scalar_chr(first_present(., c("provisioning_policy", "provisioning_policy.x", "provisioning_policy.y"), ""))
+  )
+
+run_metrics <- merged_logs %>%
+  left_join(run_strategy, by = c("run_id", "pipeline", "group")) %>%
+  left_join(run_costs, by = c("run_id", "group")) %>%
+  transmute(
+    pipeline = clean_scalar_chr(pipeline),
+    group = clean_scalar_chr(group),
+    run_id = clean_scalar_chr(run_id),
+    scheduler_mode = clean_scalar_chr(first_present(., c("scheduler_mode", "scheduler_mode.x", "scheduler_mode.y"), "")),
+    task_rightsizing = clean_scalar_chr(first_present(., c("rightsizing_mode", "rightsizing_mode.x", "rightsizing_mode.y"), "")),
+    packing = dplyr::if_else(as.logical(first_present(., c("packing_enabled", "packing_enabled.x", "packing_enabled.y"), FALSE)), "Yes", "No"),
+    vm_provisioning = clean_scalar_chr(first_present(., c("provisioning_policy", "provisioning_policy.x", "provisioning_policy.y"), "")),
+    duration = suppressWarnings(as.numeric(duration)),
+    cpuTime = suppressWarnings(as.numeric(cpuTime)),
+    task_runtime_ms = suppressWarnings(as.numeric(task_runtime_ms)),
+    pipeline_runtime = suppressWarnings(as.numeric(task_runtime_ms)),
+    cpuEfficiency = suppressWarnings(as.numeric(cpuEfficiency)),
+    memoryEfficiency = suppressWarnings(as.numeric(memoryEfficiency)),
+    schedAllocCpuEfficiency = suppressWarnings(as.numeric(schedAllocCpuEfficiency)),
+    schedAllocMemEfficiency = suppressWarnings(as.numeric(schedAllocMemEfficiency)),
+    realVmCpuEfficiency = suppressWarnings(as.numeric(realVmCpuEfficiency)),
+    realVmMemEfficiency = suppressWarnings(as.numeric(realVmMemEfficiency)),
+    nMachines = suppressWarnings(as.numeric(nMachines)),
+    vmCpuH = suppressWarnings(as.numeric(vmCpuH)),
+    vmMemGibH = suppressWarnings(as.numeric(vmMemGibH)),
+    realCpuH = suppressWarnings(as.numeric(first_present(., c("realCpuH", "realCpuH.x", "realCpuH.y"), NA_real_))),
+    realMemGibH = suppressWarnings(as.numeric(first_present(., c("realMemGibH", "realMemGibH.x", "realMemGibH.y"), NA_real_))),
+    requestedCpuH = suppressWarnings(as.numeric(first_present(., c("requestedCpuH", "requestedCpuH.x", "requestedCpuH.y"), NA_real_))),
+    requestedMemGibH = suppressWarnings(as.numeric(first_present(., c("requestedMemGibH", "requestedMemGibH.x", "requestedMemGibH.y"), NA_real_))),
+    schedulerBookedCpuH = suppressWarnings(as.numeric(schedulerBookedCpuH)),
+    schedulerBookedMemGibH = suppressWarnings(as.numeric(schedulerBookedMemGibH)),
+    schedulerRightsizedCpuH = suppressWarnings(as.numeric(schedulerRightsizedCpuH)),
+    schedulerRightsizedMemGibH = suppressWarnings(as.numeric(schedulerRightsizedMemGibH)),
+    schedulerOverbookCpuH = suppressWarnings(as.numeric(schedulerOverbookCpuH)),
+    schedulerOverbookMemGibH = suppressWarnings(as.numeric(schedulerOverbookMemGibH)),
+    vmPackingSlackCpuH = suppressWarnings(as.numeric(vmPackingSlackCpuH)),
+    vmPackingSlackMemGibH = suppressWarnings(as.numeric(vmPackingSlackMemGibH)),
+    readBytes = suppressWarnings(as.numeric(readBytes)),
+    writeBytes = suppressWarnings(as.numeric(writeBytes)),
+    cost = suppressWarnings(as.numeric(first_present(., c("cost", "cost.x", "cost.y"), NA_real_))),
+    used_cost = suppressWarnings(as.numeric(first_present(., c("used_cost", "used_cost.x", "used_cost.y"), NA_real_))),
+    unused_cost = suppressWarnings(as.numeric(first_present(., c("unused_cost", "unused_cost.x", "unused_cost.y"), NA_real_)))
+  )
+
+process_stats <- task_data_aug %>%
+  group_by(group, process_name = process, process_short) %>%
+  summarise(
+    n_tasks = n(),
+    avg_staging_min = mean(staging_time_mins, na.rm = TRUE),
+    sd_staging_min = safe_sd(staging_time_mins),
+    avg_realtime_min = mean(realtime_mins, na.rm = TRUE),
+    sd_realtime_min = safe_sd(realtime_mins),
+    avg_runtime_min = mean(runtime_mins, na.rm = TRUE),
+    sd_runtime_min = safe_sd(runtime_mins),
+    avg_cost = if (all(is.na(cost))) NA_real_ else mean(cost, na.rm = TRUE),
+    sd_cost = if (all(is.na(cost))) NA_real_ else safe_sd(cost),
+    total_cost = if (all(is.na(cost))) NA_real_ else sum(cost, na.rm = TRUE),
+    .groups = "drop"
+  )
+
+task_instance_usage <- task_data_aug %>%
+  mutate(
+    machine_type = case_when(
+      !is.na(machineType) & machineType != "" ~ machineType,
+      executor == "local" ~ "local",
+      TRUE ~ "HPC"
+    )
+  ) %>%
+  count(group, machine_type, name = "count")
+
+task_scatter <- task_data_aug %>%
+  transmute(
+    run_id = clean_scalar_chr(run_id),
+    group = clean_scalar_chr(group),
+    process_short = clean_scalar_chr(process_short),
+    name = clean_scalar_chr(name),
+    realtime_min = suppressWarnings(as.numeric(realtime_mins)),
+    staging_min = suppressWarnings(as.numeric(staging_time_mins)),
+    cost = suppressWarnings(as.numeric(cost)),
+    cpus = suppressWarnings(as.numeric(cpus)),
+    memory_gb = suppressWarnings(as.numeric(requested_memory_gib_raw))
+  )
+
+task_table <- task_data_aug %>%
+  transmute(
+    Group = clean_scalar_chr(group),
+    `Run ID` = clean_scalar_chr(run_id),
+    Taskhash = clean_scalar_chr(hash_clean),
+    `Task name short` = clean_scalar_chr(process_short),
+    Executor = clean_scalar_chr(executor),
+    Cloudzone = clean_scalar_chr(cloudZone),
+    `Instance type` = clean_scalar_chr(machineType),
+    Realtime_min = suppressWarnings(as.numeric(realtime_mins)),
+    Realtime_ms = suppressWarnings(as.numeric(realtime)),
+    Duration_ms = suppressWarnings(as.numeric(duration)),
+    Cost = suppressWarnings(as.numeric(cost)),
+    RequestedCPU = suppressWarnings(as.numeric(cpus)),
+    RequestedMemory_GiB = suppressWarnings(as.numeric(memory)),
+    ObservedCPU_pct = suppressWarnings(as.numeric(pcpu)),
+    ObservedMemory_pct = suppressWarnings(as.numeric(pmem)),
+    PeakRSS_GiB = suppressWarnings(as.numeric(rss)),
+    Readbytes = suppressWarnings(as.numeric(readBytes)),
+    Writebytes = suppressWarnings(as.numeric(writeBytes)),
+    VolCtxt = suppressWarnings(as.numeric(volCtxt)),
+    InvCtxt = suppressWarnings(as.numeric(invCtxt)),
+    `Task name` = clean_scalar_chr(name),
+    Status = clean_scalar_chr(status)
+  )
+
+report_data <- list(
+  benchmark_overview = benchmark_overview,
+  run_summary = run_summary,
+  run_metrics = run_metrics,
+  run_costs = run_costs,
+  process_stats = process_stats,
+  task_instance_usage = task_instance_usage,
+  task_table = task_table,
+  task_scatter = task_scatter,
+  cost_overview = NULL
+)
+
+report_json <- toJSON(
+  report_data,
+  dataframe = "rows",
+  auto_unbox = TRUE,
+  na = "null",
+  null = "null"
+)
+
+template <- readChar("benchmark_report_template.html", file.info("benchmark_report_template.html")$size, useBytes = TRUE)
+template <- gsub("__PUBLISHED_AT__", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), template, fixed = TRUE)
+template <- gsub("__FAILED_TASK_EXCLUDED__", if (args$remove_failed_tasks) "Yes" else "No", template, fixed = TRUE)
+template <- gsub("__REPORT_DATA__", report_json, template, fixed = TRUE)
+
+writeLines(template, con = args$output, useBytes = TRUE)

--- a/modules/local/benchmark_report/overrides/render_benchmark_report.R
+++ b/modules/local/benchmark_report/overrides/render_benchmark_report.R
@@ -89,6 +89,27 @@ safe_sd <- function(x) {
   sd(x, na.rm = TRUE)
 }
 
+build_workspace_run_url <- function(run_id, group, existing_url = "") {
+  existing_url <- clean_scalar_chr(existing_url)
+  group <- clean_scalar_chr(group)
+
+  base_url <- dplyr::if_else(
+    grepl("^Batch", group, ignore.case = TRUE),
+    "https://seqera.io/orgs/scidev/workspaces/testing/watch",
+    "https://cloud.dev-seqera.io/orgs/unified-compute/workspaces/sched-testing"
+  )
+
+  has_watch <- grepl("/watch/?$", base_url)
+  run_path <- ifelse(has_watch, paste0("/", run_id), paste0("/watch/", run_id))
+  fallback_url <- paste0(sub("/$", "", base_url), run_path)
+
+  dplyr::if_else(
+    nzchar(existing_url) & !grepl("example\\.invalid", existing_url, ignore.case = TRUE),
+    existing_url,
+    fallback_url
+  )
+}
+
 build_cost_table <- function(task_data, merged_logs, aws_cost = NULL, remove_failed_tasks = FALSE) {
   accurate_task_costs <- data.frame()
   run_group_lookup <- merged_logs %>%
@@ -341,7 +362,11 @@ run_costs <- task_data_aug %>%
   )
 
 workspace_values <- clean_scalar_chr(first_present(merged_logs, c("workspaceFullName", "workspaceName", "workspaceId"), ""))
-platform_urls <- clean_scalar_chr(first_present(merged_logs, c("runUrl"), ""))
+platform_urls <- build_workspace_run_url(
+  run_id = clean_scalar_chr(merged_logs$run_id),
+  group = clean_scalar_chr(merged_logs$group),
+  existing_url = first_present(merged_logs, c("runUrl"), "")
+)
 
 benchmark_overview <- merged_logs %>%
   transmute(

--- a/modules/local/benchmark_report/tests/main.nf.test
+++ b/modules/local/benchmark_report/tests/main.nf.test
@@ -25,9 +25,10 @@ nextflow_process {
             process {
                 """
                 input[0] = SEQERA_RUNS_DUMP.out.run_dump.collect{it[1]}
-                input[1] = SEQERA_RUNS_DUMP.out.run_dump.collect{it[0].group}
+                input[1] = SEQERA_RUNS_DUMP.out.run_dump.collect{ [group: it[0].group, file_name: new File(it[1].toString()).name, machines_name: ''] }
                 input[2] = []
-                input[3] = true
+                input[3] = []
+                input[4] = true
                 """
             }
         }

--- a/nextflow.config
+++ b/nextflow.config
@@ -318,7 +318,7 @@ manifest {
     homePage        = 'https://github.com/seqeralabs/nf-aggregate'
     description     = """Pipeline to aggregate pertinent metrics across pipeline runs on the Seqera Platform."""
     mainScript      = 'main.nf'
-    defaultBranch   = 'main'
+    defaultBranch   = 'dev'
     nextflowVersion = '!>=24.04.2'
     version         = '0.7.0'
     doi             = ''

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranches": ["dev"]
+}

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -28,11 +28,11 @@ workflow NF_AGGREGATE {
     ids
     .branch {meta ->
         external: meta.workspace == 'external'
-            if (meta.logs =~ /workflows\/nf_aggregate\/assets\/logs\//) {
-                return [meta, projectDir + meta.logs]
-            } else {
-                return [meta, meta.logs]
-            }
+            def resolvedLogs = meta.logs =~ /workflows\/nf_aggregate\/assets\/logs\// ? projectDir + meta.logs : meta.logs
+            def resolvedMachines = meta.machines ? (
+                meta.machines =~ /workflows\/nf_aggregate\/assets\// ? projectDir + meta.machines : meta.machines
+            ) : null
+            return [meta + [machines: resolvedMachines], resolvedLogs]
         fetch_run_dumps: true
     }
     .set { ids_split }
@@ -77,10 +77,21 @@ workflow NF_AGGREGATE {
     if (params.generate_benchmark_report) {
         // Check if cur report is specified
         aws_cur_report = params.benchmark_aws_cur_report ? Channel.fromPath(params.benchmark_aws_cur_report) : []
+        benchmark_machine_files = ch_all_runs
+            .map { meta, _run_dir -> meta.machines ? file(meta.machines, checkIfExists: true) : null }
+            .filter { it != null }
+            .collect()
 
         BENCHMARK_REPORT(
             ch_all_runs.collect { it[1] },
-            ch_all_runs.collect { it[0].group },
+            ch_all_runs.collect { meta, run_dir ->
+                [
+                    group        : meta.group ?: '',
+                    file_name    : run_dir.getFileName().toString(),
+                    machines_name: meta.machines ? file(meta.machines).getFileName().toString() : ''
+                ]
+            },
+            benchmark_machine_files,
             aws_cur_report,
             params.remove_failed_tasks,
         )


### PR DESCRIPTION
## Summary
- overlay the benchmark-report container sources from this repo so report fixes are versioned in nf-aggregate
- add optional `machines` CSV support for external benchmark inputs and pass machine files through the workflow
- recompute task-derived CPU and memory efficiencies from task logs, rename total task runtime semantics, and add scheduler/VM metrics when machine CSVs are available
- relabel task resource columns to distinguish requested resources from observed usage and clarify process/task duration wording

## Validation
- rendered the patched report successfully against reconstructed sample run dumps plus machine CSVs at `/tmp/nfagg_test/render/benchmark_report_fixed.html`
- `nextflow run` parses and launches the updated workflow with the external benchmark fixture inputs
