### PR TITLE
fix(report): show failed/cancelled runs in run summary table

### DIFF
--- a/bin/benchmark_report_aggregate.py
+++ b/bin/benchmark_report_aggregate.py
@@ -118,11 +118,6 @@ def build_report_data(jsonl_dir: Path) -> dict[str, Any]:
             }
         )
 
-        if not report_included:
-            continue
-
-        included_run_ids.add(run_id)
-
         run_summary.append(
             {
                 "pipeline": r.get("pipeline"),
@@ -146,6 +141,11 @@ def build_report_data(jsonl_dir: Path) -> dict[str, Any]:
                 "container_engine": r.get("container_engine"),
             }
         )
+
+        if not report_included:
+            continue
+
+        included_run_ids.add(run_id)
 
         run_metrics.append(
             {

--- a/bin/benchmark_report_template.html
+++ b/bin/benchmark_report_template.html
@@ -390,7 +390,7 @@ function downloadCSV(tableId, filename) {
 
 // Group colors
 const overviewGroups = [...new Set((DATA.benchmark_overview||[]).map(r => r.group))];
-const reportGroups = [...new Set((DATA.run_summary||[]).map(r => r.group))];
+const reportGroups = [...new Set((DATA.run_summary||[]).filter(r => r.report_included !== false).map(r => r.group))];
 const groupColor = {};
 overviewGroups.forEach((g,i) => { groupColor[g] = COLORS[i % COLORS.length]; });
 
@@ -417,11 +417,13 @@ overviewGroups.forEach((g,i) => { groupColor[g] = COLORS[i % COLORS.length]; });
     return 'unknown';
   };
   runs.forEach((r,i) => {
-    html += '<tr>';
+    html += '<tr' + (r.report_included === false ? ' style="opacity:0.6"' : '') + '>';
     cols.forEach(c => {
       const value = r[c[1]];
       if (c[1] === 'status_label') {
-        html += '<td><span class="status-badge ' + badgeClass(r) + '">' + (value || '\u2014') + '</span></td>';
+        let cell = '<span class="status-badge ' + badgeClass(r) + '">' + (value || '\u2014') + '</span>';
+        if (r.report_included === false) cell += '<span class="status-note">excluded from metrics</span>';
+        html += '<td>' + cell + '</td>';
       } else {
         html += '<td>' + (value != null ? value : '\u2014') + '</td>';
       }
@@ -540,8 +542,8 @@ function hbarStacked(elId, title, labels, seriesDefs, opts) {
   hbarChart('chart-est-cost', 'Compute cost', labels, costValues,
     { xName: '$', prefix: '$', subtitle: takeaway(labels, costValues, { lowerBetter: true, adjective: 'cheaper', prefix: '$' }) });
 
-  // Workflow status — succeeded/failed/cached stacked bars
-  const summaryRuns = DATA.run_summary || [];
+  // Workflow status — succeeded/failed/cached stacked bars (included runs only)
+  const summaryRuns = (DATA.run_summary || []).filter(r => r.report_included !== false);
   const totalSucc = summaryRuns.reduce((s,r) => s + (r.succeedCount||0), 0);
   const totalFail = summaryRuns.reduce((s,r) => s + (r.failedCount||0), 0);
   const totalCached = summaryRuns.reduce((s,r) => s + (r.cachedCount||0), 0);

--- a/modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py
+++ b/modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py
@@ -131,7 +131,11 @@ def test_failed_and_cancelled_runs_only_appear_in_overview(tmp_path, make_run, f
     assert overview["run-cancelled"]["report_included"] is False
     assert overview["run-cancelled"]["status_category"] == "cancelled"
 
-    assert [row["run_id"] for row in data["run_summary"]] == ["run-success"]
+    summary_ids = [row["run_id"] for row in data["run_summary"]]
+    assert summary_ids == ["run-success", "run-failed", "run-cancelled"]
+    assert data["run_summary"][0]["report_included"] is True
+    assert data["run_summary"][1]["report_included"] is False
+    assert data["run_summary"][2]["report_included"] is False
     assert [row["run_id"] for row in data["run_metrics"]] == ["run-success"]
     assert [row["run_id"] for row in data["run_costs"]] == ["run-success"]
     assert {row["Run ID"] for row in data["task_table"]} == {"run-success"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

PR #130 states that failed/cancelled runs should "stay visible in the summary table" but the implementation excluded them from `run_summary`, so they never appeared in the rendered Run summary table. `benchmark_overview` held all runs but was never rendered.

### Changes
- **`bin/benchmark_report_aggregate.py`**: Move the `report_included` guard to after the `run_summary.append` so all runs (including failed/cancelled) appear in `run_summary` with their `report_included` flag. Downstream sections (`run_metrics`, costs, tasks) remain filtered to included runs only.
- **`bin/benchmark_report_template.html`**: Excluded rows render with reduced opacity and an "excluded from metrics" note below the status badge. `reportGroups` and the Workflow-status chart now filter to `report_included !== false` so charts only reflect included runs.
- **`test_aggregate.py`**: Updated `test_failed_and_cancelled_runs_only_appear_in_overview` to assert `run_summary` contains all three runs with correct `report_included` flags, while `run_metrics` still only has the success run.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).

## Verification

All tests pass locally:

- `pre-commit run --all-files` — prettier, editorconfig: passed
- `pytest -v` (27 tests) — all passed
- `nf-test test --profile=+docker --verbose` (4 tests) — all passed
- E2E pipeline run — report generated successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37fd3eb9-0ac9-4e0a-9b64-0ddc54e623d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37fd3eb9-0ac9-4e0a-9b64-0ddc54e623d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

