### PR TITLE
ci: gate benchmark report checks by changed files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,14 @@ jobs:
 
       - name: Run offline benchmark smoke test
         run: |
-          nextflow run . --input workflows/nf_aggregate/assets/test_benchmark.csv --generate_benchmark_report --outdir benchmark-smoke-results -profile docker
+          cat > benchmark-smoke-params.json <<'JSON'
+          {
+            "input": "workflows/nf_aggregate/assets/test_benchmark.csv",
+            "generate_benchmark_report": true,
+            "outdir": "benchmark-smoke-results"
+          }
+          JSON
+          nextflow run . -params-file benchmark-smoke-params.json -profile docker
 
   confirm-pass:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       nf_test_files: ${{ steps.list.outputs.components }}
+      benchmark_pytest: ${{ steps.benchmark.outputs.benchmark_pytest }}
+      benchmark_smoke: ${{ steps.benchmark.outputs.benchmark_smoke }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -39,12 +41,104 @@ jobs:
         uses: adamrtalbot/detect-nf-test-changes@v0.0.3
         with:
           head: ${{ github.sha }}
-          base: origin/${{ github.base_ref }}
+          base: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
           include: .github/include.yaml
 
       - name: print list of nf-test files
         run: |
           echo ${{ steps.list.outputs.components }}
+
+      - name: Detect benchmark report changes
+        id: benchmark
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            BASE_SHA="$PR_BASE_SHA"
+          elif [[ "$EVENT_NAME" == "merge_group" ]]; then
+            BASE_SHA="$MERGE_GROUP_BASE_SHA"
+          else
+            echo "benchmark_pytest=false" >> "$GITHUB_OUTPUT"
+            echo "benchmark_smoke=false" >> "$GITHUB_OUTPUT"
+            echo "Benchmark report checks are disabled for event: $EVENT_NAME"
+            exit 0
+          fi
+
+          echo "Comparing benchmark-report surfaces between $BASE_SHA and $HEAD_SHA"
+          CHANGED_FILES="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          export CHANGED_FILES GITHUB_OUTPUT
+
+          python <<'PY'
+          import fnmatch
+          import os
+
+          changed = [line.strip() for line in os.environ.get("CHANGED_FILES", "").splitlines() if line.strip()]
+          pytest_patterns = [
+              ".github/workflows/ci.yml",
+              ".github/include.yaml",
+              "bin/aggregate_benchmark_report_data.py",
+              "bin/benchmark_report.py",
+              "bin/benchmark_report_aggregate.py",
+              "bin/benchmark_report_normalize.py",
+              "bin/benchmark_report_render.py",
+              "bin/benchmark_report_template.html",
+              "bin/normalize_benchmark_jsonl.py",
+              "bin/render_benchmark_report.py",
+              "bin/test_benchmark_report_fetch.py",
+              "conftest.py",
+              "modules/local/aggregate_benchmark_report_data/**",
+              "modules/local/normalize_benchmark_jsonl/**",
+              "modules/local/render_benchmark_report/**",
+              "scripts/build_filtered_cost_sidecar.py",
+              "tests/pipeline_benchmark_*/**",
+              "workflows/nf_aggregate/assets/log_dirs/**",
+              "workflows/nf_aggregate/assets/logs/**",
+              "workflows/nf_aggregate/assets/realworld_log_dirs/**",
+              "workflows/nf_aggregate/assets/test_benchmark*.csv",
+              "workflows/nf_aggregate/assets/test_benchmark*.parquet",
+          ]
+          smoke_patterns = pytest_patterns + [
+              "assets/brand.yml",
+              "assets/schema_input.json",
+              "main.nf",
+              "modules/local/extract_tarball/**",
+              "nextflow.config",
+              "nextflow_schema.json",
+              "workflows/nf_aggregate/main.nf",
+              "workflows/nf_aggregate/nextflow.config",
+          ]
+
+          def matched_files(patterns):
+              return sorted({
+                  path for path in changed
+                  if any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+              })
+
+          pytest_matches = matched_files(pytest_patterns)
+          smoke_matches = matched_files(smoke_patterns)
+
+          print("Benchmark-report pytest matches:")
+          if pytest_matches:
+              for path in pytest_matches:
+                  print(f"  - {path}")
+          else:
+              print("  (none)")
+
+          print("Benchmark-report smoke matches:")
+          if smoke_matches:
+              for path in smoke_matches:
+                  print(f"  - {path}")
+          else:
+              print("  (none)")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"benchmark_pytest={'true' if pytest_matches else 'false'}\n")
+              fh.write(f"benchmark_smoke={'true' if smoke_matches else 'false'}\n")
+          PY
 
   test:
     name: ${{ matrix.nf_test_files }} ${{ matrix.profile }} NF-${{ matrix.NXF_VER }}
@@ -115,11 +209,54 @@ jobs:
         with:
           report_paths: test.xml
 
+  benchmark-report-pytest:
+    name: Benchmark report pytest
+    needs: [changes]
+    if: needs.changes.outputs.benchmark_pytest == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+          architecture: "x64"
+
+      - name: Install uv
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+
+      - name: Run benchmark report pytest suites
+        run: |
+          uv run --with typer --with pyyaml --with jinja2 --with pyarrow --with pytest --with httpx pytest -v modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py modules/local/normalize_benchmark_jsonl/tests/test_normalize.py modules/local/render_benchmark_report/tests/test_render.py bin/test_benchmark_report_fetch.py
+
+  benchmark-report-smoke:
+    name: Benchmark report smoke test
+    needs: [changes]
+    if: needs.changes.outputs.benchmark_smoke == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install Nextflow
+        uses: nf-core/setup-nextflow@v2
+        with:
+          version: "latest-everything"
+
+      - name: Run offline benchmark smoke test
+        run: |
+          nextflow run . --input workflows/nf_aggregate/assets/test_benchmark.csv --generate_benchmark_report --outdir benchmark-smoke-results -profile docker
+
   confirm-pass:
     runs-on: ubuntu-latest
     needs:
       - changes
       - test
+      - benchmark-report-pytest
+      - benchmark-report-smoke
     if: always()
     steps:
       - name: All tests ok


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool, parameter, or workflow path, update the relevant docs.
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Add selective benchmark-report CI coverage to `.github/workflows/ci.yml` without widening PR runtime for unrelated changes.

### What changed
- Keep the existing `changes` job as the single source of change detection.
- Add benchmark-report-specific change detection based on `git diff` between the PR / merge-group base SHA and the current head SHA.
- Add a gated `Benchmark report pytest` job that runs the documented benchmark-report pytest command only when benchmark-report Python, render/template, fixture, or benchmark integration test surfaces change.
- Add a gated `Benchmark report smoke test` job that runs the offline `nextflow run . --input workflows/nf_aggregate/assets/test_benchmark.csv --generate_benchmark_report ... -profile docker` command only when pipeline entrypoints/config, extract-tarball routing, branding/schema, or benchmark-report surfaces change.
- Run the smoke test via `-params-file` so `generate_benchmark_report` is passed as a real boolean across GitHub runners / Nextflow combinations.
- Wire both new jobs into the existing `confirm-pass` aggregation job.
- Make the existing nf-test change detector use base SHAs that work for both `pull_request` and `merge_group` events.

### Why
The current PR workflows cover nf-test and linting well, but they do not automatically run the highest-signal benchmark-report pytest suites or an independent offline benchmark-report smoke run. This change adds those checks while preserving CI performance by only running them when the touched files can actually affect benchmark-report behavior.

### Root cause of the PR failure
The first revision of the smoke job passed `--generate_benchmark_report` on the CLI. On GitHub’s runner / Nextflow combination, that value was validated as a string instead of a boolean and failed schema validation. The updated smoke job now uses a JSON params file so the boolean type is preserved.

### Local validation
- `nextflow run . -params-file /tmp/benchmark-smoke-params.json -profile docker`
- `pre-commit run --all-files`
- Parsed the workflow YAML successfully after the change.
- Exercised the benchmark path-gating rules locally and confirmed:
  - docs-only changes => no benchmark jobs
  - workflow entrypoint changes => smoke job only
  - benchmark Python/render changes => pytest + smoke
  - extract-tarball-only changes => smoke job only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7805680-2c23-453e-914c-6b156687ff1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7805680-2c23-453e-914c-6b156687ff1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

