### PR TITLE
feat: support custom CUR label aliases

### DIFF
--- a/.seqera/context/PIPELINE.md
+++ b/.seqera/context/PIPELINE.md
@@ -51,22 +51,22 @@ Input CSV (id, workspace, group, logs, platform, token_env)
 | Process                           | Container                       | Input                                       | Output                      |
 | --------------------------------- | ------------------------------- | ------------------------------------------- | --------------------------- |
 | `EXTRACT_TARBALL`                 | ubuntu:22.04                    | `(meta, tarball)`                           | `(meta, dir)` of JSON files |
-| `NORMALIZE_BENCHMARK_JSONL`       | wave python/duckdb/jinja2/typer | `data_dir`, `cur_parquet`, `cur_label_map` | `jsonl_bundle/`             |
+| `NORMALIZE_BENCHMARK_JSONL`       | wave python/duckdb/jinja2/typer | `data_dir`, `cur_parquet`, `cur_label_map`  | `jsonl_bundle/`             |
 | `AGGREGATE_BENCHMARK_REPORT_DATA` | wave python/duckdb/jinja2/typer | `jsonl_bundle/`                             | `report_data.json`          |
 | `RENDER_BENCHMARK_REPORT`         | wave python/duckdb/jinja2/typer | `report_data.json`, `brand.yml`, `logo.svg` | `benchmark_report.html`     |
 
 ## Key Parameters
 
-| Parameter                   | Default                       | Purpose                                     |
-| --------------------------- | ----------------------------- | ------------------------------------------- |
-| `input`                     | required                      | CSV samplesheet of run IDs / external paths |
-| `outdir`                    | `results`                     | Output directory                            |
-| `generate_benchmark_report` | `false`                       | Enable the benchmark pipeline               |
-| `benchmark_aws_cur_report`  | `null`                        | AWS CUR parquet for cost analysis           |
-| `benchmark_aws_cur_label_map` | `null`                      | Optional YAML alias map for CUR resource labels |
-| `seqera_api_endpoint`       | `https://api.cloud.seqera.io` | Platform API base URL                       |
-| `java_truststore_path`      | `null`                        | Custom Java truststore for private certs    |
-| `java_truststore_password`  | `null`                        | Truststore password                         |
+| Parameter                     | Default                       | Purpose                                         |
+| ----------------------------- | ----------------------------- | ----------------------------------------------- |
+| `input`                       | required                      | CSV samplesheet of run IDs / external paths     |
+| `outdir`                      | `results`                     | Output directory                                |
+| `generate_benchmark_report`   | `false`                       | Enable the benchmark pipeline                   |
+| `benchmark_aws_cur_report`    | `null`                        | AWS CUR parquet for cost analysis               |
+| `benchmark_aws_cur_label_map` | `null`                        | Optional YAML alias map for CUR resource labels |
+| `seqera_api_endpoint`         | `https://api.cloud.seqera.io` | Platform API base URL                           |
+| `java_truststore_path`        | `null`                        | Custom Java truststore for private certs        |
+| `java_truststore_password`    | `null`                        | Truststore password                             |
 
 ## Input Schema
 

--- a/.seqera/context/PIPELINE.md
+++ b/.seqera/context/PIPELINE.md
@@ -51,7 +51,7 @@ Input CSV (id, workspace, group, logs, platform, token_env)
 | Process                           | Container                       | Input                                       | Output                      |
 | --------------------------------- | ------------------------------- | ------------------------------------------- | --------------------------- |
 | `EXTRACT_TARBALL`                 | ubuntu:22.04                    | `(meta, tarball)`                           | `(meta, dir)` of JSON files |
-| `NORMALIZE_BENCHMARK_JSONL`       | wave python/duckdb/jinja2/typer | `data_dir`, `cur_parquet`                   | `jsonl_bundle/`             |
+| `NORMALIZE_BENCHMARK_JSONL`       | wave python/duckdb/jinja2/typer | `data_dir`, `cur_parquet`, `cur_label_map` | `jsonl_bundle/`             |
 | `AGGREGATE_BENCHMARK_REPORT_DATA` | wave python/duckdb/jinja2/typer | `jsonl_bundle/`                             | `report_data.json`          |
 | `RENDER_BENCHMARK_REPORT`         | wave python/duckdb/jinja2/typer | `report_data.json`, `brand.yml`, `logo.svg` | `benchmark_report.html`     |
 
@@ -63,6 +63,7 @@ Input CSV (id, workspace, group, logs, platform, token_env)
 | `outdir`                    | `results`                     | Output directory                            |
 | `generate_benchmark_report` | `false`                       | Enable the benchmark pipeline               |
 | `benchmark_aws_cur_report`  | `null`                        | AWS CUR parquet for cost analysis           |
+| `benchmark_aws_cur_label_map` | `null`                      | Optional YAML alias map for CUR resource labels |
 | `seqera_api_endpoint`       | `https://api.cloud.seqera.io` | Platform API base URL                       |
 | `java_truststore_path`      | `null`                        | Custom Java truststore for private certs    |
 | `java_truststore_password`  | `null`                        | Truststore password                         |

--- a/.seqera/skills/rebuild-benchmark-report-locally/SKILL.md
+++ b/.seqera/skills/rebuild-benchmark-report-locally/SKILL.md
@@ -37,6 +37,7 @@ Use those boundaries to isolate failures instead of re-running everything.
 uv run --with typer --with pyyaml --with pyarrow \
   python bin/benchmark_report.py normalize-jsonl \
   --data-dir /path/to/json_data \
+  --cost-label-map /path/to/cur_label_map.yml \
   --output-dir /tmp/jsonl_bundle
 ```
 
@@ -47,6 +48,7 @@ uv run --with typer --with pyyaml --with pyarrow \
   python bin/benchmark_report.py normalize-jsonl \
   --data-dir /path/to/json_data \
   --costs /path/to/cur.parquet \
+  --cost-label-map /path/to/cur_label_map.yml \
   --output-dir /tmp/jsonl_bundle
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,10 @@ input CSV (id, workspace, group, logs, fusion)
 
 | Param                       | Default                       | Purpose                           |
 | --------------------------- | ----------------------------- | --------------------------------- |
-| `generate_benchmark_report` | false                         | Enable benchmark report           |
-| `benchmark_aws_cur_report`  | null                          | AWS CUR parquet for cost analysis |
-| `seqera_api_endpoint`       | `https://api.cloud.seqera.io` | Platform API URL                  |
+| `generate_benchmark_report`   | false                         | Enable benchmark report                           |
+| `benchmark_aws_cur_report`    | null                          | AWS CUR parquet for cost analysis                 |
+| `benchmark_aws_cur_label_map` | null                          | YAML aliases for custom CUR resource label names  |
+| `seqera_api_endpoint`         | `https://api.cloud.seqera.io` | Platform API URL                                  |
 
 ## Plugins
 
@@ -37,6 +38,13 @@ input CSV (id, workspace, group, logs, fusion)
 uv run --with typer --with pyyaml --with pyarrow \
   python bin/benchmark_report.py normalize-jsonl \
   --data-dir /path/to/json_data --output-dir /tmp/jsonl_bundle
+
+# Normalize raw run JSON with CUR cost enrichment + custom label aliases:
+uv run --with typer --with pyyaml --with pyarrow \
+  python bin/benchmark_report.py normalize-jsonl \
+  --data-dir /path/to/json_data --costs /path/to/cur.parquet \
+  --cost-label-map /path/to/cur_label_map.yml \
+  --output-dir /tmp/jsonl_bundle
 
 # Aggregate JSONL bundle to report data:
 uv run --with typer --with pyyaml \

--- a/README.md
+++ b/README.md
@@ -102,6 +102,27 @@ nextflow run seqeralabs/nf-aggregate \
 
 The benchmark report can be generated without cost data - simply omit the `--benchmark_aws_cur_report` parameter if cost analysis is not needed.
 
+When CUR data is provided, nf-aggregate only joins cost rows that carry the resource labels needed to match a Nextflow task back to a benchmark run. The required keys are:
+
+- run ID: `user_unique_run_id` or `user_nf_unique_run_id`
+- process name: `user_pipeline_process`
+- task hash: `user_task_hash`
+
+The normalizer accepts both of the common CUR layouts:
+
+- flattened CUR columns such as `resource_tags_user_unique_run_id`, `resource_tags_user_pipeline_process`, and `resource_tags_user_task_hash`
+- map-style `resource_tags` entries containing `user_unique_run_id`, `user_pipeline_process`, and `user_task_hash`
+
+If those labels are missing from the CUR export, the benchmark report still renders, but CUR-backed cost rows cannot be associated with runs or tasks.
+
+For AWS Batch or other cloud executors that propagate resource labels into CUR tags, configure labels equivalent to:
+
+```
+user_unique_run_id=${workflow.runId}
+user_pipeline_process=${task.process}
+user_task_hash=${task.hash}
+```
+
 For a checked-in real-world example that exercises external run JSON directories plus a tiny filtered cost parquet, see:
 
 - `workflows/nf_aggregate/assets/test_benchmark_realworld_costs.csv`

--- a/README.md
+++ b/README.md
@@ -100,18 +100,45 @@ nextflow run seqeralabs/nf-aggregate \
     --benchmark_aws_cur_report ./aws_cost_report.parquet
 ```
 
+If your CUR export uses custom resource label names, pass an optional YAML alias map with `benchmark_aws_cur_label_map`:
+
+```
+nextflow run seqeralabs/nf-aggregate \
+    --input run_ids.csv \
+    --outdir ./results \
+    --generate_benchmark_report \
+    --benchmark_aws_cur_report ./aws_cost_report.parquet \
+    --benchmark_aws_cur_label_map ./cur_label_map.yml
+```
+
 The benchmark report can be generated without cost data - simply omit the `--benchmark_aws_cur_report` parameter if cost analysis is not needed.
 
-When CUR data is provided, nf-aggregate only joins cost rows that carry the resource labels needed to match a Nextflow task back to a benchmark run. The required keys are:
+When CUR data is provided, nf-aggregate only joins cost rows that carry the resource labels needed to match a Nextflow task back to a benchmark run. By default the logical fields map to:
 
 - run ID: `user_unique_run_id` or `user_nf_unique_run_id`
 - process name: `user_pipeline_process`
 - task hash: `user_task_hash`
 
+To accept manual/custom label names, create a YAML file listing aliases for the logical fields:
+
+```
+run_id:
+  - my_team_run_id
+  - user_unique_run_id
+process:
+  - my_process_label
+  - user_pipeline_process
+task_hash:
+  - my_task_hash_label
+  - user_task_hash
+```
+
+Aliases are tried in order, then the built-in defaults are still checked as a fallback.
+
 The normalizer accepts both of the common CUR layouts:
 
-- flattened CUR columns such as `resource_tags_user_unique_run_id`, `resource_tags_user_pipeline_process`, and `resource_tags_user_task_hash`
-- map-style `resource_tags` entries containing `user_unique_run_id`, `user_pipeline_process`, and `user_task_hash`
+- flattened CUR columns such as `resource_tags_user_unique_run_id`, `resource_tags_my_process_label`, and `resource_tags_user_task_hash`
+- map-style `resource_tags` entries containing `user_unique_run_id`, `my_process_label`, and `user_task_hash`
 
 If those labels are missing from the CUR export, the benchmark report still renders, but CUR-backed cost rows cannot be associated with runs or tasks.
 
@@ -138,6 +165,8 @@ python scripts/build_filtered_cost_sidecar.py \
     --run-ids-csv workflows/nf_aggregate/assets/test_benchmark_realworld_costs.csv \
     --output workflows/nf_aggregate/assets/test_benchmark_realworld_costs.parquet
 ```
+
+The helper script also accepts `--cost-label-map ./cur_label_map.yml` when the monthly CUR export uses custom run-id label aliases.
 
 Add `--include-red-herring` only if you want one synthetic non-benchmark row for robustness testing.
 

--- a/bin/benchmark_report.py
+++ b/bin/benchmark_report.py
@@ -28,12 +28,19 @@ def normalize_jsonl_cmd(
     data_dir: Path = typer.Option(..., exists=True, help="Directory containing run JSON files"),
     output_dir: Path = typer.Option(Path("jsonl_bundle"), help="Output JSONL bundle directory"),
     costs: Path = typer.Option(None, help="Optional AWS CUR parquet file"),
+    cost_label_map: Path = typer.Option(None, help="Optional YAML file mapping logical CUR labels to custom tag aliases"),
     machines_dir: Path = typer.Option(None, help="Optional machine metrics CSV directory"),
 ) -> None:
     """Normalize raw run JSON into runs/tasks/metrics JSONL files."""
     from benchmark_report_normalize import normalize_jsonl
 
-    normalize_jsonl(data_dir=data_dir, output_dir=output_dir, costs_parquet=costs, machines_dir=machines_dir)
+    normalize_jsonl(
+        data_dir=data_dir,
+        output_dir=output_dir,
+        costs_parquet=costs,
+        cost_label_map=cost_label_map,
+        machines_dir=machines_dir,
+    )
 
 
 @app.command("aggregate-report-data")

--- a/bin/normalize_benchmark_jsonl.py
+++ b/bin/normalize_benchmark_jsonl.py
@@ -14,9 +14,16 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--data-dir", type=Path, required=True, help="Directory containing run JSON files")
     parser.add_argument("--output-dir", type=Path, default=Path("jsonl_bundle"), help="Output JSONL bundle directory")
     parser.add_argument("--costs", type=Path, default=None, help="Optional AWS CUR parquet file")
+    parser.add_argument("--cost-label-map", type=Path, default=None, help="Optional YAML mapping for CUR resource label aliases")
     parser.add_argument("--machines-dir", type=Path, default=None, help="Directory containing machine metrics CSVs")
     args = parser.parse_args(argv)
-    normalize_jsonl(data_dir=args.data_dir, output_dir=args.output_dir, costs_parquet=args.costs, machines_dir=args.machines_dir)
+    normalize_jsonl(
+        data_dir=args.data_dir,
+        output_dir=args.output_dir,
+        costs_parquet=args.costs,
+        cost_label_map=args.cost_label_map,
+        machines_dir=args.machines_dir,
+    )
 
 
 if __name__ == "__main__":

--- a/bin/test_build_filtered_cost_sidecar.py
+++ b/bin/test_build_filtered_cost_sidecar.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+
+import pyarrow as pa
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import build_filtered_cost_sidecar as sidecar
+
+
+def test_build_run_ids_prefers_custom_map_alias_over_default_flat_column():
+    aliases = sidecar._dedupe_aliases(["custom_run", *sidecar.DEFAULT_RUN_ID_ALIASES])
+    table = pa.table(
+        {
+            "resource_tags_user_unique_run_id": ["run-default"],
+            "resource_tags": [[("custom_run", "run-custom")]],
+        }
+    )
+
+    run_id_column = sidecar.choose_run_id_column(table.schema, aliases)
+
+    assert run_id_column == "resource_tags_user_unique_run_id"
+    assert sidecar.build_run_ids(table, run_id_column, aliases) == ["run-custom"]

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -33,6 +33,7 @@ Command:
 
 ```bash
 python bin/benchmark_report.py normalize-jsonl --data-dir <run_json_dir> --output-dir <jsonl_bundle>
+python bin/benchmark_report.py normalize-jsonl --data-dir <run_json_dir> --costs <cur.parquet> --cost-label-map <cur_label_map.yml> --output-dir <jsonl_bundle>
 ```
 
 Responsibilities:
@@ -119,6 +120,13 @@ results/benchmark_report/
 uv run --with typer --with pyyaml --with pyarrow \
   python bin/benchmark_report.py normalize-jsonl \
   --data-dir /path/to/json_data --output-dir /tmp/jsonl_bundle
+
+uv run --with typer --with pyyaml --with pyarrow \
+  python bin/benchmark_report.py normalize-jsonl \
+  --data-dir /path/to/json_data \
+  --costs /path/to/cur.parquet \
+  --cost-label-map /path/to/cur_label_map.yml \
+  --output-dir /tmp/jsonl_bundle
 
 uv run --with typer --with pyyaml \
   python bin/benchmark_report.py aggregate-report-data \

--- a/modules/local/normalize_benchmark_jsonl/bin/benchmark_report_normalize.py
+++ b/modules/local/normalize_benchmark_jsonl/bin/benchmark_report_normalize.py
@@ -11,6 +11,12 @@ from typing import Any
 
 import typer
 
+DEFAULT_COST_LABEL_ALIASES: dict[str, list[str]] = {
+    "run_id": ["user_unique_run_id", "user_nf_unique_run_id"],
+    "process": ["user_pipeline_process"],
+    "task_hash": ["user_task_hash"],
+}
+
 
 def _run_group(run: dict[str, Any]) -> str:
     return run["meta"]["group"]
@@ -239,22 +245,78 @@ def _iter_parquet_rows(costs_parquet: Path):
             yield cols, row
 
 
-def _normalize_cost_rows(costs_parquet: Path) -> list[dict[str, Any]]:
+def _dedupe_aliases(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    aliases: list[str] = []
+    for value in values:
+        alias = str(value).strip()
+        if not alias or alias in seen:
+            continue
+        seen.add(alias)
+        aliases.append(alias)
+    return aliases
+
+
+def _normalise_label_aliases(value: Any, field: str) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return _dedupe_aliases([value])
+    if isinstance(value, list):
+        if not all(isinstance(item, str) for item in value):
+            raise ValueError(f"benchmark_aws_cur_label_map field '{field}' must contain only strings")
+        return _dedupe_aliases(value)
+    raise ValueError(f"benchmark_aws_cur_label_map field '{field}' must be a string or list of strings")
+
+
+def _load_cost_label_aliases(cost_label_map: Path | None = None) -> dict[str, list[str]]:
+    aliases = {field: list(defaults) for field, defaults in DEFAULT_COST_LABEL_ALIASES.items()}
+    if cost_label_map is None or cost_label_map.name in {"NO_FILE", "NO_FILE_CUR_LABEL_MAP"}:
+        return aliases
+
+    try:
+        import yaml
+    except ImportError as exc:
+        raise RuntimeError("pyyaml is required to read benchmark_aws_cur_label_map") from exc
+
+    with cost_label_map.open() as handle:
+        raw_config = yaml.safe_load(handle) or {}
+
+    if not isinstance(raw_config, dict):
+        raise ValueError("benchmark_aws_cur_label_map must contain a YAML mapping")
+
+    unknown_fields = set(raw_config) - set(DEFAULT_COST_LABEL_ALIASES)
+    if unknown_fields:
+        unknown_fields_csv = ", ".join(sorted(unknown_fields))
+        raise ValueError(f"benchmark_aws_cur_label_map contains unsupported fields: {unknown_fields_csv}")
+
+    for field, defaults in DEFAULT_COST_LABEL_ALIASES.items():
+        user_aliases = _normalise_label_aliases(raw_config.get(field), field)
+        aliases[field] = _dedupe_aliases(user_aliases + defaults)
+
+    return aliases
+
+
+def _resolve_cost_label_value(row: dict[str, Any], tags: dict[str, Any], aliases: list[str]) -> Any:
+    for alias in aliases:
+        flat_value = row.get(f"resource_tags_{alias}")
+        if flat_value not in (None, ""):
+            return flat_value
+        tag_value = tags.get(alias)
+        if tag_value not in (None, ""):
+            return tag_value
+    return None
+
+
+def _normalize_cost_rows(costs_parquet: Path, cost_label_map: Path | None = None) -> list[dict[str, Any]]:
     grouped: dict[tuple[str, str, str], dict[str, float | str]] = {}
-    is_map: bool | None = None
+    label_aliases = _load_cost_label_aliases(cost_label_map)
 
     for cols, row in _iter_parquet_rows(costs_parquet):
-        if is_map is None:
-            is_map = "resource_tags" in cols and "resource_tags_user_unique_run_id" not in cols
-        if is_map:
-            tags = _to_tags_dict(row.get("resource_tags"))
-            run_id = tags.get("user_unique_run_id") or tags.get("user_nf_unique_run_id")
-            process = tags.get("user_pipeline_process")
-            hash_val = tags.get("user_task_hash")
-        else:
-            run_id = row.get("resource_tags_user_unique_run_id") or row.get("resource_tags_user_nf_unique_run_id")
-            process = row.get("resource_tags_user_pipeline_process")
-            hash_val = row.get("resource_tags_user_task_hash")
+        tags = _to_tags_dict(row.get("resource_tags")) if "resource_tags" in cols else {}
+        run_id = _resolve_cost_label_value(row, tags, label_aliases["run_id"])
+        process = _resolve_cost_label_value(row, tags, label_aliases["process"])
+        hash_val = _resolve_cost_label_value(row, tags, label_aliases["task_hash"])
 
         if not run_id:
             continue
@@ -434,7 +496,13 @@ def _summarise_machines(machines_dir: Path) -> list[dict[str, Any]]:
     return results
 
 
-def normalize_jsonl(data_dir: Path, output_dir: Path, costs_parquet: Path | None = None, machines_dir: Path | None = None) -> None:
+def normalize_jsonl(
+    data_dir: Path,
+    output_dir: Path,
+    costs_parquet: Path | None = None,
+    machines_dir: Path | None = None,
+    cost_label_map: Path | None = None,
+) -> None:
     runs = load_run_data(data_dir)
     if not runs:
         typer.echo("No run data found", err=True)
@@ -451,7 +519,7 @@ def normalize_jsonl(data_dir: Path, output_dir: Path, costs_parquet: Path | None
     _write_jsonl(output_dir / "metrics.jsonl", metric_rows)
 
     if costs_parquet and costs_parquet.exists() and costs_parquet.name != "NO_FILE":
-        cost_rows = _normalize_cost_rows(costs_parquet)
+        cost_rows = _normalize_cost_rows(costs_parquet, cost_label_map=cost_label_map)
         _write_jsonl(output_dir / "costs.jsonl", cost_rows)
 
     if machines_dir and machines_dir.exists() and any(machines_dir.glob("*.csv")):

--- a/modules/local/normalize_benchmark_jsonl/main.nf
+++ b/modules/local/normalize_benchmark_jsonl/main.nf
@@ -6,6 +6,7 @@ process NORMALIZE_BENCHMARK_JSONL {
     input:
     path data_dir
     path benchmark_aws_cur_report
+    path benchmark_aws_cur_label_map
     path machines_dir
 
     output:
@@ -14,11 +15,13 @@ process NORMALIZE_BENCHMARK_JSONL {
 
     script:
     def cost_flag = benchmark_aws_cur_report.name != 'NO_FILE' && benchmark_aws_cur_report.name != 'NO_FILE_CUR' ? "--costs ${benchmark_aws_cur_report}" : ""
+    def label_map_flag = benchmark_aws_cur_label_map.name != 'NO_FILE' && benchmark_aws_cur_label_map.name != 'NO_FILE_CUR_LABEL_MAP' ? "--cost-label-map ${benchmark_aws_cur_label_map}" : ""
     def machines_flag = machines_dir.name != 'NO_FILE' && machines_dir.name != 'NO_FILE_MACHINES' ? "--machines-dir ${machines_dir}" : ""
     """
     normalize_benchmark_jsonl.py \\
         --data-dir ${data_dir} \\
         ${cost_flag} \\
+        ${label_map_flag} \\
         ${machines_flag} \\
         --output-dir jsonl_bundle
 

--- a/modules/local/normalize_benchmark_jsonl/tests/test_normalize.py
+++ b/modules/local/normalize_benchmark_jsonl/tests/test_normalize.py
@@ -2,8 +2,17 @@ import json
 
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
 
-from benchmark_report_normalize import _normalize_cost_rows, _summarise_machines, extract_runs, extract_tasks, load_run_data, normalize_jsonl
+from benchmark_report_normalize import (
+    _load_cost_label_aliases,
+    _normalize_cost_rows,
+    _summarise_machines,
+    extract_runs,
+    extract_tasks,
+    load_run_data,
+    normalize_jsonl,
+)
 
 
 def test_cached_count_extracted(make_run, flat_task):
@@ -105,6 +114,108 @@ def test_normalize_cost_rows_reads_parquet_in_batches(tmp_path):
             "unused_cost": 1.0,
         }
     ]
+
+
+def test_normalize_cost_rows_accepts_custom_flat_aliases(tmp_path):
+    parquet_path = tmp_path / "costs-flat-custom.parquet"
+    label_map_path = tmp_path / "cur_label_map.yml"
+    label_map_path.write_text(
+        "run_id:\n"
+        "  - manual_run_label\n"
+        "process:\n"
+        "  - manual_process_label\n"
+        "task_hash:\n"
+        "  - manual_hash_label\n"
+    )
+    table = pa.table(
+        {
+            "resource_tags_manual_run_label": ["run9", "run9"],
+            "resource_tags_manual_process_label": ["PROC_Z", "PROC_Z"],
+            "resource_tags_manual_hash_label": ["1122334455aa", "1122334455aa"],
+            "split_line_item_split_cost": [1.0, 2.0],
+            "split_line_item_unused_cost": [0.5, 0.25],
+        }
+    )
+    pq.write_table(table, parquet_path, row_group_size=1)
+
+    rows = _normalize_cost_rows(parquet_path, cost_label_map=label_map_path)
+
+    assert rows == [
+        {
+            "run_id": "run9",
+            "process": "PROC_Z",
+            "hash": "11223344",
+            "cost": 3.75,
+            "used_cost": 3.0,
+            "unused_cost": 0.75,
+        }
+    ]
+
+
+def test_normalize_cost_rows_accepts_custom_resource_tag_aliases(tmp_path):
+    parquet_path = tmp_path / "costs-map-custom.parquet"
+    label_map_path = tmp_path / "cur_label_map.yml"
+    label_map_path.write_text(
+        "run_id: manual_run_label\n"
+        "process: manual_process_label\n"
+        "task_hash: manual_hash_label\n"
+    )
+    table = pa.table(
+        {
+            "resource_tags": [
+                [
+                    ("manual_run_label", "run-map"),
+                    ("manual_process_label", "PROC_MAP"),
+                    ("manual_hash_label", "aa11bb22cc33"),
+                ]
+            ],
+            "split_line_item_split_cost": [2.5],
+            "split_line_item_unused_cost": [0.5],
+        }
+    )
+    pq.write_table(table, parquet_path)
+
+    rows = _normalize_cost_rows(parquet_path, cost_label_map=label_map_path)
+
+    assert rows == [
+        {
+            "run_id": "run-map",
+            "process": "PROC_MAP",
+            "hash": "aa11bb22",
+            "cost": 3.0,
+            "used_cost": 2.5,
+            "unused_cost": 0.5,
+        }
+    ]
+
+
+def test_normalize_cost_rows_prefers_user_aliases_before_defaults(tmp_path):
+    parquet_path = tmp_path / "costs-prefer-custom.parquet"
+    label_map_path = tmp_path / "cur_label_map.yml"
+    label_map_path.write_text("run_id: manual_run_label\n")
+    table = pa.table(
+        {
+            "resource_tags_manual_run_label": ["run-custom"],
+            "resource_tags_user_unique_run_id": ["run-default"],
+            "resource_tags_user_pipeline_process": ["PROC_A"],
+            "resource_tags_user_task_hash": ["abcdef123456"],
+            "split_line_item_split_cost": [1.0],
+            "split_line_item_unused_cost": [0.0],
+        }
+    )
+    pq.write_table(table, parquet_path)
+
+    rows = _normalize_cost_rows(parquet_path, cost_label_map=label_map_path)
+
+    assert rows[0]["run_id"] == "run-custom"
+
+
+def test_load_cost_label_aliases_rejects_unknown_fields(tmp_path):
+    label_map_path = tmp_path / "invalid_cur_label_map.yml"
+    label_map_path.write_text("unexpected: value\n")
+
+    with pytest.raises(ValueError, match="unsupported fields"):
+        _load_cost_label_aliases(label_map_path)
 
 
 def test_load_run_data(tmp_path, make_run, write_run_json):

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,6 +20,7 @@ params {
     // Benchmark report options
     generate_benchmark_report    = false
     benchmark_aws_cur_report     = null
+    benchmark_aws_cur_label_map  = null
 
     // Boilerplate options
     outdir                       = 'results'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -67,6 +67,13 @@
                     "description": "AWS CUR report from data exports.",
                     "pattern": "^\\S+\\.parquet",
                     "format": "file-path"
+                },
+                "benchmark_aws_cur_label_map": {
+                    "type": "string",
+                    "fa_icon": "fas fa-tags",
+                    "description": "Optional YAML file mapping logical benchmark cost labels to one or more CUR resource tag aliases.",
+                    "pattern": "^\\S+\\.(ya?ml)$",
+                    "format": "file-path"
                 }
             },
             "required": ["seqera_api_endpoint"]

--- a/scripts/build_filtered_cost_sidecar.py
+++ b/scripts/build_filtered_cost_sidecar.py
@@ -9,11 +9,7 @@ from pathlib import Path
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-RUN_ID_COLUMNS = [
-    'resource_tags_user_unique_run_id',
-    'resource_tags_user_nf_unique_run_id',
-]
-RUN_ID_TAG_KEYS = [
+DEFAULT_RUN_ID_ALIASES = [
     'user_unique_run_id',
     'user_nf_unique_run_id',
 ]
@@ -40,14 +36,53 @@ def load_run_rows(csv_path: Path) -> list[dict[str, str]]:
         return list(csv.DictReader(handle))
 
 
-def choose_run_id_column(schema: pa.Schema) -> str | None:
-    for name in RUN_ID_COLUMNS:
+def _dedupe_aliases(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    aliases: list[str] = []
+    for value in values:
+        alias = str(value).strip()
+        if not alias or alias in seen:
+            continue
+        seen.add(alias)
+        aliases.append(alias)
+    return aliases
+
+
+def _load_run_id_aliases(label_map_path: Path | None) -> list[str]:
+    aliases = list(DEFAULT_RUN_ID_ALIASES)
+    if label_map_path is None:
+        return aliases
+
+    try:
+        import yaml
+    except ImportError as exc:
+        raise SystemExit('pyyaml is required to read --label-map') from exc
+
+    with label_map_path.open() as handle:
+        raw_config = yaml.safe_load(handle) or {}
+
+    if not isinstance(raw_config, dict):
+        raise SystemExit('--label-map must contain a YAML mapping')
+
+    user_aliases = raw_config.get('run_id')
+    if user_aliases is None:
+        return aliases
+    if isinstance(user_aliases, str):
+        return _dedupe_aliases([user_aliases] + aliases)
+    if isinstance(user_aliases, list) and all(isinstance(item, str) for item in user_aliases):
+        return _dedupe_aliases(user_aliases + aliases)
+    raise SystemExit("--label-map field 'run_id' must be a string or list of strings")
+
+
+def choose_run_id_column(schema: pa.Schema, aliases: list[str]) -> str | None:
+    for alias in aliases:
+        name = f'resource_tags_{alias}'
         if name in schema.names:
             return name
     return None
 
 
-def build_run_ids(table: pa.Table, run_id_column: str | None) -> list[str | None]:
+def build_run_ids(table: pa.Table, run_id_column: str | None, aliases: list[str]) -> list[str | None]:
     if run_id_column is not None:
         return table[run_id_column].combine_chunks().to_pylist()
     if 'resource_tags' not in table.schema.names:
@@ -57,7 +92,7 @@ def build_run_ids(table: pa.Table, run_id_column: str | None) -> list[str | None
     for raw_tags in table['resource_tags'].to_pylist():
         tag_map = dict(raw_tags or [])
         run_id = None
-        for key in RUN_ID_TAG_KEYS:
+        for key in aliases:
             if key in tag_map:
                 run_id = tag_map[key]
                 break
@@ -72,6 +107,7 @@ def main() -> None:
     parser.add_argument('cur_parquet', type=Path, help='Path to the monthly CUR parquet file')
     parser.add_argument('--run-ids-csv', type=Path, required=True, help='CSV containing benchmark run IDs')
     parser.add_argument('--output', type=Path, required=True, help='Output parquet path')
+    parser.add_argument('--label-map', type=Path, help='Optional YAML mapping file matching benchmark_aws_cur_label_map')
     parser.add_argument(
         '--include-red-herring',
         action='store_true',
@@ -82,10 +118,11 @@ def main() -> None:
     run_rows = load_run_rows(args.run_ids_csv)
     run_lookup = {row['id']: {'group': row.get('group', 'default')} for row in run_rows}
     target_run_ids = set(run_lookup)
+    run_id_aliases = _load_run_id_aliases(args.label_map)
 
     table = pq.read_table(args.cur_parquet)
-    run_id_column = choose_run_id_column(table.schema)
-    run_ids = build_run_ids(table, run_id_column)
+    run_id_column = choose_run_id_column(table.schema, run_id_aliases)
+    run_ids = build_run_ids(table, run_id_column, run_id_aliases)
     keep_columns = [name for name in KEEP_COLUMNS if name in table.schema.names]
     column_values = {name: table[name].combine_chunks().to_pylist() for name in keep_columns}
 
@@ -96,7 +133,7 @@ def main() -> None:
         row = {
             'fixture_run_id': run_id,
             'fixture_group': run_lookup[run_id]['group'],
-            'fixture_run_id_source': run_id_column or 'resource_tags.' + '|'.join(RUN_ID_TAG_KEYS),
+            'fixture_run_id_source': run_id_column or 'resource_tags.' + '|'.join(run_id_aliases),
         }
         for name in keep_columns:
             row[name] = column_values[name][idx]

--- a/scripts/build_filtered_cost_sidecar.py
+++ b/scripts/build_filtered_cost_sidecar.py
@@ -82,19 +82,45 @@ def choose_run_id_column(schema: pa.Schema, aliases: list[str]) -> str | None:
     return None
 
 
+def _to_tags_dict(value: object) -> dict[str, object]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, list):
+        tags: dict[str, object] = {}
+        for item in value:
+            if isinstance(item, (tuple, list)) and len(item) == 2:
+                tags[str(item[0])] = item[1]
+        return tags
+    return {}
+
+
 def build_run_ids(table: pa.Table, run_id_column: str | None, aliases: list[str]) -> list[str | None]:
-    if run_id_column is not None:
-        return table[run_id_column].combine_chunks().to_pylist()
-    if 'resource_tags' not in table.schema.names:
+    flat_alias_values = {
+        alias: table[f'resource_tags_{alias}'].combine_chunks().to_pylist()
+        for alias in aliases
+        if f'resource_tags_{alias}' in table.schema.names
+    }
+    has_resource_tags = 'resource_tags' in table.schema.names
+    if not flat_alias_values and not has_resource_tags:
         raise SystemExit('No supported run-id column or resource_tags map found in parquet schema')
 
+    raw_tags_values = table['resource_tags'].to_pylist() if has_resource_tags else [None] * table.num_rows
     values: list[str | None] = []
-    for raw_tags in table['resource_tags'].to_pylist():
-        tag_map = dict(raw_tags or [])
+    for idx, raw_tags in enumerate(raw_tags_values):
+        tag_map = _to_tags_dict(raw_tags)
         run_id = None
-        for key in aliases:
-            if key in tag_map:
-                run_id = tag_map[key]
+        for alias in aliases:
+            flat_values = flat_alias_values.get(alias)
+            if flat_values is not None:
+                flat_value = flat_values[idx]
+                if flat_value not in (None, ''):
+                    run_id = flat_value
+                    break
+            tag_value = tag_map.get(alias)
+            if tag_value not in (None, ''):
+                run_id = tag_value
                 break
         values.append(run_id)
     return values

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -125,6 +125,10 @@ workflow NF_AGGREGATE {
             ? Channel.fromPath(params.benchmark_aws_cur_report)
             : Channel.fromPath("${projectDir}/assets/NO_FILE_CUR", checkIfExists: false).ifEmpty(file("${projectDir}/assets/NO_FILE_CUR"))
 
+        ch_cur_label_map = params.benchmark_aws_cur_label_map
+            ? Channel.fromPath(params.benchmark_aws_cur_label_map)
+            : Channel.fromPath("${projectDir}/assets/NO_FILE_CUR_LABEL_MAP", checkIfExists: false).ifEmpty(file("${projectDir}/assets/NO_FILE_CUR_LABEL_MAP"))
+
         // Collect machine metrics CSVs from external runs (if present)
         ch_machines_dir = ch_split.external
             .filter { it.machines }
@@ -146,6 +150,7 @@ workflow NF_AGGREGATE {
         NORMALIZE_BENCHMARK_JSONL(
             ch_data_dir,
             ch_cur.ifEmpty(file("${projectDir}/assets/NO_FILE_CUR")),
+            ch_cur_label_map.ifEmpty(file("${projectDir}/assets/NO_FILE_CUR_LABEL_MAP")),
             ch_machines_dir,
         )
         ch_versions = ch_versions.mix(NORMALIZE_BENCHMARK_JSONL.out.versions)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, parameter, or workflow path, update the relevant docs.
- [ ] If plugin declarations changed, update `CITATIONS.md`, `README.md`, and agent/context guidance in the same PR.
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `README.md` is updated (including new tool citations and authors/contributors).

## Description

This PR expands benchmark cost enrichment so users can provide custom CUR resource label aliases instead of being limited to the built-in `user_unique_run_id` / `user_nf_unique_run_id`, `user_pipeline_process`, and `user_task_hash` names.

### New feature

Add optional `benchmark_aws_cur_label_map` YAML config support. The mapping file declares aliases for the logical benchmark cost fields:

- `run_id`
- `process`
- `task_hash`

The normalizer now resolves those aliases against both supported CUR layouts:

- flattened `resource_tags_<alias>` columns
- map-style `resource_tags` entries

If no mapping file is supplied, the current default aliases still apply.

### Included updates

- thread `benchmark_aws_cur_label_map` through config, schema, workflow, and normalize CLI
- resolve custom aliases during CUR normalization
- update `scripts/build_filtered_cost_sidecar.py` to honor the same run-id alias mapping
- document the new parameter and show example YAML config in `README.md`
- sync agent/context/design docs with the new public parameter
- add focused normalize tests covering custom flat aliases, custom map aliases, precedence, and config validation

## Validation

- `uv run --with typer --with pyyaml --with jinja2 --with pyarrow --with pytest --with httpx pytest -v modules/local/normalize_benchmark_jsonl/tests/test_normalize.py`
- `pre-commit run --all-files`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3673670-cc9e-49a5-849d-d10ac8427425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3673670-cc9e-49a5-849d-d10ac8427425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

