### PR TITLE
Improve Seqera API preflight errors

### DIFF
--- a/.seqera/context/ERRORS.md
+++ b/.seqera/context/ERRORS.md
@@ -22,13 +22,21 @@ Both runs `1cF65l2PDvxNd5` (maniac_celsius) and `5VGC0gjEmghOaz` (clever_kalman)
 
 **Fix:** Verify the org/workspace names in the input CSV match the Platform exactly (case-sensitive).
 
-### 3. API Rate Limiting / Transient Failures
+### 3. API Endpoint / Token Preflight Failure
+
+**When:** The API endpoint is wrong, unreachable, or the access token is invalid.
+
+**Error:** `RuntimeException: Seqera Platform API preflight failed at '<endpoint>/service-info' ...` or `RuntimeException: Authentication failed at '<endpoint>/user-info' ...`
+
+**Fix:** Verify `--seqera_api_endpoint` (or the samplesheet `platform` column), network/truststore settings, and the token stored in `TOWER_ACCESS_TOKEN` (or the per-row `token_env` override).
+
+### 4. API Rate Limiting / Transient Failures
 
 **When:** Fetching data from busy Platform instances with many concurrent runs.
 
 **Mitigation:** Built-in retry with exponential backoff (3 attempts, 1s/2s/4s delays). After 3 failures, the pipeline aborts with the original error.
 
-### 4. Wave Container Build Failures
+### 5. Wave Container Build Failures
 
 **When:** Using `wave` profile with `spack` strategy.
 
@@ -36,7 +44,7 @@ Both runs `1cF65l2PDvxNd5` (maniac_celsius) and `5VGC0gjEmghOaz` (clever_kalman)
 
 **Fix:** The wave profile explicitly uses `strategy = ['conda', 'container', 'dockerfile']` — no spack. Don't add spack to the strategy list.
 
-### 5. CGROUPv2 Docker Failures (Cloud VM / Firecracker)
+### 6. CGROUPv2 Docker Failures (Cloud VM / Firecracker)
 
 **When:** Running with Docker in Cloud VMs where cgroup resource delegation is restricted.
 
@@ -44,7 +52,7 @@ Both runs `1cF65l2PDvxNd5` (maniac_celsius) and `5VGC0gjEmghOaz` (clever_kalman)
 
 **Fix:** Apply the runc wrapper documented in AGENTS.md that strips `linux.resources` from the OCI spec.
 
-### 6. Empty Benchmark Report
+### 7. Empty Benchmark Report
 
 **When:** API runs are provided but `--generate_benchmark_report` is not set.
 
@@ -52,7 +60,7 @@ Both runs `1cF65l2PDvxNd5` (maniac_celsius) and `5VGC0gjEmghOaz` (clever_kalman)
 
 **Fix:** Add `--generate_benchmark_report` to the run command.
 
-### 7. Scheduling Overhead (Observed Pattern)
+### 8. Scheduling Overhead (Observed Pattern)
 
 **Not an error per se**, but both current runs show 4–8 minute gaps between task submit and task start times. This is expected with AWS Batch spot instances — EC2 instances must be provisioned and containers pulled before execution begins. Not actionable unless overhead exceeds ~15 minutes consistently.
 

--- a/.seqera/context/PIPELINE.md
+++ b/.seqera/context/PIPELINE.md
@@ -88,7 +88,7 @@ results/
 
 ## Data Flow Details
 
-1. **API path:** `SeqeraApi.fetchRunData()` runs in Groovy process memory (not a Nextflow task). It resolves workspace name → ID, then fetches `/workflow/{id}`, `/workflow/{id}/metrics`, `/workflow/{id}/tasks` (paginated), and `/workflow/{id}/progress`. Results are written to temp JSON files.
+1. **API path:** `SeqeraApi.fetchRunData()` runs in Groovy process memory (not a Nextflow task). It first validates the configured Platform endpoint with `/service-info` and the bearer token with `/user-info`, then resolves workspace name → ID and fetches `/workflow/{id}`, `/workflow/{id}/metrics`, `/workflow/{id}/tasks` (paginated), and `/workflow/{id}/progress`. Results are written to temp JSON files.
 2. **External path:** EXTRACT_TARBALL unpacks `.tar.gz` into a directory of JSON files. Directories are used directly.
 3. **All JSON files** are collected into a single temp directory and passed to the 3-stage Python pipeline: normalize → aggregate → render.
 4. The Python stages are separate Nextflow processes sharing one Wave container image (`python_duckdb_jinja2_typer_pruned`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Thank you to everyone else that has contributed by reporting bugs, enhancements 
 
 ### Enhancements & fixes
 
+- Improve Seqera API preflight errors for invalid API endpoints and access tokens
 - [PR #88](https://github.com/seqeralabs/nf-aggregate/pull/88) - Update tw cli container version to 0.11.2 and allow .nextflow.log to be missing from tw call
 - [PR #89](https://github.com/seqeralabs/nf-aggregate/pull/89) - Enable usage of external run dumps with nf-aggregate & update devcontainer specifications
 - [PR #91](https://github.com/seqeralabs/nf-aggregate/pull/91) - Update benchmark report image to include a fix causing large memory footprint for reshaping large AWS cost report files

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 The pipeline fetches run data from the Seqera Platform API and generates benchmark reports comparing pipeline runs.
 
+Before the pipeline resolves workspaces or fetches run details, it performs API preflight checks against `/service-info` and `/user-info`. This helps surface misconfigured API endpoints, missing truststore configuration, and invalid access tokens with explicit error messages.
+
 ## Prerequisites
 
 - [Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#installation) >=25.10.0

--- a/bin/benchmark_report_fetch.py
+++ b/bin/benchmark_report_fetch.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+from functools import lru_cache
+from urllib.error import HTTPError, URLError
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from urllib.request import Request, urlopen
 
@@ -19,6 +21,62 @@ def _api_get(url: str, headers: dict[str, str], params: dict[str, str] | None = 
     req = Request(url, headers=headers)
     with urlopen(req) as resp:
         return json.loads(resp.read())
+
+
+def _format_http_error(exc: HTTPError) -> str:
+    return f"API request failed: {exc.url} → HTTP {exc.code}"
+
+
+@lru_cache(maxsize=None)
+def _validate_api_access_cached(api_endpoint: str, authorization: str, token_env_var: str) -> None:
+    headers = {"Authorization": authorization}
+
+    try:
+        _api_get(f"{api_endpoint}/service-info", headers=headers)
+    except HTTPError as exc:
+        raise RuntimeError(
+            "Seqera Platform API preflight failed at "
+            f"'{api_endpoint}/service-info'. Check the API endpoint URL from "
+            "--api-endpoint or the input samplesheet platform column. "
+            f"Original error: {_format_http_error(exc)}"
+        ) from exc
+    except URLError as exc:
+        raise RuntimeError(
+            "Could not reach Seqera Platform API preflight endpoint "
+            f"'{api_endpoint}/service-info'. Check the API endpoint URL, network "
+            f"access, and TLS configuration. Original error: {exc.reason}"
+        ) from exc
+
+    try:
+        _api_get(f"{api_endpoint}/user-info", headers=headers)
+    except HTTPError as exc:
+        if exc.code in {401, 403}:
+            raise RuntimeError(
+                "Authentication failed at "
+                f"'{api_endpoint}/user-info'. Check the access token stored in "
+                f"'{token_env_var}'. Original error: {_format_http_error(exc)}"
+            ) from exc
+        raise RuntimeError(
+            "Seqera Platform API auth preflight failed at "
+            f"'{api_endpoint}/user-info'. Check the API endpoint URL and the "
+            f"access token stored in '{token_env_var}'. Original error: "
+            f"{_format_http_error(exc)}"
+        ) from exc
+    except URLError as exc:
+        raise RuntimeError(
+            "Could not complete Seqera Platform auth preflight at "
+            f"'{api_endpoint}/user-info'. Check network access and the access "
+            f"token stored in '{token_env_var}'. Original error: {exc.reason}"
+        ) from exc
+
+
+def validate_api_access(
+    api_endpoint: str,
+    headers: dict[str, str],
+    token_env_var: str = "TOWER_ACCESS_TOKEN",
+) -> None:
+    authorization = headers.get("Authorization", "")
+    _validate_api_access_cached(api_endpoint, authorization, token_env_var)
 
 
 def resolve_workspace_id(workspace: str, api_endpoint: str, headers: dict[str, str]) -> int:
@@ -67,6 +125,7 @@ def fetch_all_tasks(base_url: str, headers: dict[str, str]) -> list[dict]:
 
 def fetch_run_data(run_id: str, workspace: str, api_endpoint: str, token: str) -> dict:
     headers = {"Authorization": f"Bearer {token}"}
+    validate_api_access(api_endpoint, headers=headers)
     ws_id = resolve_workspace_id(workspace, api_endpoint, headers)
 
     workflow_data = _api_get(

--- a/bin/test_benchmark_report_fetch.py
+++ b/bin/test_benchmark_report_fetch.py
@@ -1,8 +1,9 @@
+from urllib.error import HTTPError
 from unittest.mock import patch
 
 import pytest
 
-from benchmark_report_fetch import fetch_all_tasks, fetch_run_data, resolve_workspace_id
+from benchmark_report_fetch import fetch_all_tasks, fetch_run_data, resolve_workspace_id, validate_api_access
 
 
 def test_resolve_workspace_id():
@@ -33,12 +34,32 @@ def test_fetch_all_tasks_paginates():
 
 def test_fetch_run_data_keys():
     with patch("benchmark_report_fetch.resolve_workspace_id", return_value=10):
-        with patch("benchmark_report_fetch._api_get") as mock_get:
-            with patch("benchmark_report_fetch.fetch_all_tasks", return_value=[{"task": {"id": 1}}]):
-                mock_get.side_effect = [
-                    {"workflow": {"id": "run1"}},
-                    {"metrics": []},
-                    {"progress": {"workflowProgress": {}}},
-                ]
-                data = fetch_run_data("run1", "org/ws", "https://api.example.com", "tok")
-                assert set(data.keys()) == {"workflow", "metrics", "tasks", "progress"}
+        with patch("benchmark_report_fetch.validate_api_access") as mock_validate:
+            with patch("benchmark_report_fetch._api_get") as mock_get:
+                with patch("benchmark_report_fetch.fetch_all_tasks", return_value=[{"task": {"id": 1}}]):
+                    mock_get.side_effect = [
+                        {"workflow": {"id": "run1"}},
+                        {"metrics": []},
+                        {"progress": {"workflowProgress": {}}},
+                    ]
+                    data = fetch_run_data("run1", "org/ws", "https://api.example.com", "tok")
+                    assert set(data.keys()) == {"workflow", "metrics", "tasks", "progress"}
+                    mock_validate.assert_called_once_with("https://api.example.com", headers={"Authorization": "Bearer tok"})
+
+
+def test_validate_api_access_bad_token():
+    error = HTTPError("https://api.example.com/user-info", 401, "Unauthorized", hdrs=None, fp=None)
+
+    with patch("benchmark_report_fetch._api_get") as mock_get:
+        mock_get.side_effect = [{}, error]
+
+        with pytest.raises(RuntimeError, match="Authentication failed at 'https://api.example.com/user-info'"):
+            validate_api_access("https://api.example.com", headers={"Authorization": "Bearer tok"})
+
+
+def test_validate_api_access_bad_endpoint():
+    error = HTTPError("https://bad.example.com/service-info", 404, "Not Found", hdrs=None, fp=None)
+
+    with patch("benchmark_report_fetch._api_get", side_effect=error):
+        with pytest.raises(RuntimeError, match="preflight failed at 'https://bad.example.com/service-info'"):
+            validate_api_access("https://bad.example.com", headers={"Authorization": "Bearer tok"})

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -13,10 +13,16 @@ Plain `java.net.URL.openConnection()` HTTP client for Seqera Platform API. Used 
 | `apiGet(url, headers)`                                | Single GET request, returns parsed JSON map                                      |
 | `apiGetAllTasks(baseUrl, headers)`                    | Paginated GET for `/tasks` endpoint (100/page)                                   |
 | `resolveWorkspaceId(workspace, apiEndpoint, headers)` | "org/workspace" string → numeric workspace ID                                    |
-| `fetchRunData(meta, apiEndpoint)`                     | Orchestrator: calls 4 endpoints per run → `{workflow, metrics, tasks, progress}` |
+| `fetchRunData(meta, apiEndpoint)`                     | Orchestrator: preflights `/service-info` + `/user-info`, then calls 4 run endpoints → `{workflow, metrics, tasks, progress}` |
 
-### API Endpoints Called (per run)
+### API Endpoints Called
 
+Preflight once per endpoint/token pair:
+
+1. `GET /service-info` — validates the API endpoint is reachable
+2. `GET /user-info` — validates the bearer token before workspace resolution
+
+Per run:
 1. `GET /workflow/{id}?workspaceId={wsId}` — run metadata
 2. `GET /workflow/{id}/metrics?workspaceId={wsId}` — resource metrics
 3. `GET /workflow/{id}/tasks?workspaceId={wsId}` — all tasks (paginated)
@@ -35,3 +41,4 @@ Calls `/orgs` → finds org by name → calls `/orgs/{orgId}/workspaces` → fin
 - Uses plain `java.net.URL.openConnection()` for HTTP requests — no external plugin dependency
 - Runs in the Nextflow head JVM, not in a container process
 - Network errors throw `RuntimeException` which will fail the pipeline
+- Bad endpoints fail during `/service-info` preflight; bad or expired tokens fail during `/user-info` preflight

--- a/lib/SeqeraApi.groovy
+++ b/lib/SeqeraApi.groovy
@@ -1,15 +1,27 @@
 // Seqera Platform API client using plain java.net HTTP
 
+class SeqeraApiRequestException extends RuntimeException {
+    final String url
+    final int statusCode
+
+    SeqeraApiRequestException(String url, int statusCode) {
+        super("API request failed: ${url} → HTTP ${statusCode}")
+        this.url = url
+        this.statusCode = statusCode
+    }
+}
+
 class SeqeraApi {
+    private static final Set<String> validatedApiSessions = Collections.synchronizedSet(new HashSet<String>())
 
     static Map apiGet(String url, Map headers) {
-        def conn = new URL(url).openConnection()
+        def conn = (HttpURLConnection) new URL(url).openConnection()
         try {
             conn.setRequestMethod('GET')
             headers.each { k, v -> conn.setRequestProperty(k, v) }
             def code = conn.getResponseCode()
             if (code != 200) {
-                throw new RuntimeException("API request failed: ${url} → HTTP ${code}")
+                throw new SeqeraApiRequestException(url, code)
             }
             def stream = conn.getInputStream()
             try {
@@ -20,6 +32,65 @@ class SeqeraApi {
             }
         } finally {
             conn.disconnect()
+        }
+    }
+
+    static void validateApiAccess(String apiEndpoint, Map headers, String tokenEnvVar, String token) {
+        def validationKey = "${apiEndpoint}|${tokenEnvVar}|${token.hashCode()}"
+        if (validatedApiSessions.contains(validationKey)) {
+            return
+        }
+
+        synchronized (validatedApiSessions) {
+            if (validatedApiSessions.contains(validationKey)) {
+                return
+            }
+
+            try {
+                apiGet("${apiEndpoint}/service-info", headers)
+            } catch (SeqeraApiRequestException e) {
+                throw new RuntimeException(
+                    "Seqera Platform API preflight failed at '${apiEndpoint}/service-info'. " +
+                    "Check the API endpoint URL from --seqera_api_endpoint or the input samplesheet platform column. " +
+                    "Original error: ${e.message}",
+                    e
+                )
+            } catch (Exception e) {
+                throw new RuntimeException(
+                    "Could not reach Seqera Platform API preflight endpoint '${apiEndpoint}/service-info'. " +
+                    "Check the API endpoint URL, network access, and JVM truststore settings. " +
+                    "Original error: ${e.message}",
+                    e
+                )
+            }
+
+            try {
+                apiGet("${apiEndpoint}/user-info", headers)
+            } catch (SeqeraApiRequestException e) {
+                if (e.statusCode in [401, 403]) {
+                    throw new RuntimeException(
+                        "Authentication failed at '${apiEndpoint}/user-info'. " +
+                        "Check the access token stored in '${tokenEnvVar}'. " +
+                        "Original error: ${e.message}",
+                        e
+                    )
+                }
+                throw new RuntimeException(
+                    "Seqera Platform API auth preflight failed at '${apiEndpoint}/user-info'. " +
+                    "Check the API endpoint URL and the access token stored in '${tokenEnvVar}'. " +
+                    "Original error: ${e.message}",
+                    e
+                )
+            } catch (Exception e) {
+                throw new RuntimeException(
+                    "Could not complete Seqera Platform auth preflight at '${apiEndpoint}/user-info'. " +
+                    "Check network access and the access token stored in '${tokenEnvVar}'. " +
+                    "Original error: ${e.message}",
+                    e
+                )
+            }
+
+            validatedApiSessions.add(validationKey)
         }
     }
 
@@ -79,6 +150,7 @@ class SeqeraApi {
             )
         }
         def headers = ["Authorization": "Bearer ${token}"]
+        validateApiAccess(effectiveEndpoint, headers, tokenEnvVar, token)
         def wsId = resolveWorkspaceId(meta.workspace, effectiveEndpoint, headers)
         def base = "${effectiveEndpoint}/workflow/${meta.id}?workspaceId=${wsId}"
 

--- a/lib/SeqeraApi.groovy
+++ b/lib/SeqeraApi.groovy
@@ -36,7 +36,11 @@ class SeqeraApi {
     }
 
     static void validateApiAccess(String apiEndpoint, Map headers, String tokenEnvVar, String token) {
-        def validationKey = "${apiEndpoint}|${tokenEnvVar}|${token.hashCode()}"
+        def tokenDigest = java.security.MessageDigest.getInstance('SHA-256')
+            .digest(token.getBytes('UTF-8'))
+            .collect { String.format('%02x', it) }
+            .join()
+        def validationKey = "${apiEndpoint}|${tokenEnvVar}|${tokenDigest}"
         if (validatedApiSessions.contains(validationKey)) {
             return
         }

--- a/lib/SeqeraApi.groovy
+++ b/lib/SeqeraApi.groovy
@@ -1,18 +1,18 @@
 // Seqera Platform API client using plain java.net HTTP
 
-class SeqeraApiRequestException extends RuntimeException {
-    final String url
-    final int statusCode
-
-    SeqeraApiRequestException(String url, int statusCode) {
-        super("API request failed: ${url} → HTTP ${statusCode}")
-        this.url = url
-        this.statusCode = statusCode
-    }
-}
-
 class SeqeraApi {
     private static final Set<String> validatedApiSessions = Collections.synchronizedSet(new HashSet<String>())
+
+    static class ApiRequestException extends RuntimeException {
+        final String url
+        final int statusCode
+
+        ApiRequestException(String url, int statusCode) {
+            super("API request failed: ${url} → HTTP ${statusCode}")
+            this.url = url
+            this.statusCode = statusCode
+        }
+    }
 
     static Map apiGet(String url, Map headers) {
         def conn = (HttpURLConnection) new URL(url).openConnection()
@@ -21,7 +21,7 @@ class SeqeraApi {
             headers.each { k, v -> conn.setRequestProperty(k, v) }
             def code = conn.getResponseCode()
             if (code != 200) {
-                throw new SeqeraApiRequestException(url, code)
+                throw new ApiRequestException(url, code)
             }
             def stream = conn.getInputStream()
             try {
@@ -48,7 +48,7 @@ class SeqeraApi {
 
             try {
                 apiGet("${apiEndpoint}/service-info", headers)
-            } catch (SeqeraApiRequestException e) {
+            } catch (ApiRequestException e) {
                 throw new RuntimeException(
                     "Seqera Platform API preflight failed at '${apiEndpoint}/service-info'. " +
                     "Check the API endpoint URL from --seqera_api_endpoint or the input samplesheet platform column. " +
@@ -66,7 +66,7 @@ class SeqeraApi {
 
             try {
                 apiGet("${apiEndpoint}/user-info", headers)
-            } catch (SeqeraApiRequestException e) {
+            } catch (ApiRequestException e) {
                 if (e.statusCode in [401, 403]) {
                     throw new RuntimeException(
                         "Authentication failed at '${apiEndpoint}/user-info'. " +

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Layout
 
-Each pipeline-level scenario lives in its own directory:
+Pipeline-level scenarios live in their own directories:
 
 - `pipeline_api_only/`
 - `pipeline_mixed_no_benchmark/`
@@ -16,13 +16,21 @@ Each scenario directory contains:
 - `main.nf.test.snap` — the snapshot for that scenario
 - `AGENTS.md` — scenario-specific guidance for future edits
 
+Function-level nf-test coverage for `lib/` helpers lives separately under:
+
+- `lib/`
+
+Reference: nf-test Function Testing docs — https://www.nf-test.com/docs/testcases/nextflow_function/
+
 ## Conventions
 
 - One scenario per directory.
 - Keep assertions local and explicit rather than heavily abstracted.
 - Prefer stable fixture files under `workflows/nf_aggregate/assets/`.
 - If routing behavior changes, update the scenario-specific `AGENTS.md` along with the test.
-- This directory is for pipeline routing/integration scenarios only; stage-specific pytest tests now live beside the relevant module under `modules/local/*/tests/`.
+- Pipeline routing/integration scenarios live under `tests/pipeline_*/`.
+- Function-level nf-test coverage for Groovy helpers under `lib/` lives under `tests/lib/`.
+- Stage-specific pytest tests live beside the relevant module under `modules/local/*/tests/`.
 
 ## Running tests
 

--- a/tests/lib/AGENTS.md
+++ b/tests/lib/AGENTS.md
@@ -1,0 +1,18 @@
+# tests/lib/
+
+## Purpose
+
+This directory holds nf-test `nextflow_function` tests for helper code under `lib/`.
+
+Current coverage:
+
+- `SeqeraApi.groovy.test` — unit-ish behavioral coverage for `SeqeraApi` helpers using nf-test function tests and inline Groovy stubbing.
+
+## Conventions
+
+Reference: nf-test Function Testing docs — https://www.nf-test.com/docs/testcases/nextflow_function/
+
+- Prefer `nextflow_function` tests here instead of introducing a separate Spock/Gradle harness.
+- Keep assertions local and explicit.
+- Stub `SeqeraApi.metaClass.'static'.apiGet` inline when isolating pagination or workspace-resolution behavior.
+- Reserve pipeline routing/integration scenarios for the sibling `tests/pipeline_*/` directories.

--- a/tests/lib/SeqeraApi.groovy.test
+++ b/tests/lib/SeqeraApi.groovy.test
@@ -1,0 +1,89 @@
+nextflow_function {
+    name "SeqeraApi helper functions"
+
+    test("apiGetAllTasks paginates until the final short page") {
+        function "SeqeraApi.apiGetAllTasks"
+
+        when {
+            function {
+                """
+                SeqeraApi.metaClass.'static'.apiGet = { String url, Map headers ->
+                    if (url.contains('offset=0')) {
+                        return [tasks: (1..100).collect { [taskId: it] }]
+                    }
+                    if (url.contains('offset=100')) {
+                        return [tasks: [[taskId: 101], [taskId: 102]]]
+                    }
+                    throw new RuntimeException("Unexpected URL: \${url}")
+                }
+
+                input[0] = 'https://example.com/tasks?workspaceId=55'
+                input[1] = [Authorization: 'Bearer test-token']
+                """
+            }
+        }
+
+        then {
+            assert function.success
+            assert function.result*.taskId == (1..102).toList()
+        }
+    }
+
+    test("resolveWorkspaceId returns the matching workspace id") {
+        function "SeqeraApi.resolveWorkspaceId"
+
+        when {
+            function {
+                """
+                SeqeraApi.metaClass.'static'.apiGet = { String url, Map headers ->
+                    if (url == 'https://api.example.com/orgs') {
+                        return [organizations: [[name: 'acme', orgId: 7], [name: 'other', orgId: 8]]]
+                    }
+                    if (url == 'https://api.example.com/orgs/7/workspaces') {
+                        return [workspaces: [[name: 'workspace-a', id: 11], [name: 'workspace-b', id: 42]]]
+                    }
+                    throw new RuntimeException("Unexpected URL: \${url}")
+                }
+
+                input[0] = 'acme/workspace-b'
+                input[1] = 'https://api.example.com'
+                input[2] = [Authorization: 'Bearer test-token']
+                """
+            }
+        }
+
+        then {
+            assert function.success
+            assert function.result == 42L
+        }
+    }
+
+    test("resolveWorkspaceId fails when the workspace is missing") {
+        function "SeqeraApi.resolveWorkspaceId"
+
+        when {
+            function {
+                """
+                SeqeraApi.metaClass.'static'.apiGet = { String url, Map headers ->
+                    if (url == 'https://api.example.com/orgs') {
+                        return [organizations: [[name: 'acme', orgId: 7]]]
+                    }
+                    if (url == 'https://api.example.com/orgs/7/workspaces') {
+                        return [workspaces: [[name: 'workspace-a', id: 11]]]
+                    }
+                    throw new RuntimeException("Unexpected URL: \${url}")
+                }
+
+                input[0] = 'acme/workspace-b'
+                input[1] = 'https://api.example.com'
+                input[2] = [Authorization: 'Bearer test-token']
+                """
+            }
+        }
+
+        then {
+            assert function.failed
+            assert function.stdout.any { it.contains("Workspace 'workspace-b' not found in org 'acme'") }
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, parameter, or workflow path, update the relevant docs.
- [x] If plugin declarations changed, update `CITATIONS.md`, `README.md`, and agent/context guidance in the same PR.
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Issue #72 is still reproducible on current `main`: an invalid token currently retries `/orgs` and fails with a generic `API request failed ... HTTP 401` message.

This change adds a shared API preflight step before workspace resolution:
- validate the configured endpoint with `GET /service-info`
- validate auth with `GET /user-info`
- emit specific guidance for invalid endpoints, auth failures, and network/TLS failures
- cache successful validations per endpoint/token so repeated run fetches do not recheck unnecessarily

It also aligns the standalone Python fetch helper with the same behavior, adds focused regression tests, and updates the docs/context describing the API path and known failure modes.

## Testing

- [x] `uv run --with typer --with pyyaml --with jinja2 --with pyarrow --with pytest --with httpx pytest -v modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py modules/local/normalize_benchmark_jsonl/tests/test_normalize.py modules/local/render_benchmark_report/tests/test_render.py bin/test_benchmark_report_fetch.py`
- [x] `nf-test test --profile=+docker --verbose`
- [x] `nextflow run . --input workflows/nf_aggregate/assets/test_benchmark.csv --generate_benchmark_report --outdir /tmp/nf-aggregate-e2e-results -profile docker`
- [x] `pre-commit run --all-files`
- [x] `TOWER_ACCESS_TOKEN=bad-token nextflow run . --input /tmp/issue72_run_ids.csv --generate_benchmark_report --seqera_api_endpoint http://127.0.0.1:8765 --outdir /tmp/issue72-bad-token -ansi-log false`
- [x] `TOWER_ACCESS_TOKEN=good-token nextflow run . --input /tmp/issue72_run_ids.csv --generate_benchmark_report --seqera_api_endpoint http://127.0.0.1:9999 --outdir /tmp/issue72-bad-endpoint -ansi-log false`

The two issue-specific runs confirm the pipeline now fails at `/user-info` for bad tokens and `/service-info` for bad endpoints, instead of surfacing a generic `/orgs` failure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c0035fb-d551-4a14-8aa1-4c6f1afdbc67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c0035fb-d551-4a14-8aa1-4c6f1afdbc67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

