### PR TITLE
Add automated release draft changelog

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,6 +26,15 @@ If you're not used to this workflow with git, you can start with some [docs from
 When you create a pull request with changes, [GitHub Actions](https://github.com/features/actions) will run automatic tests.
 Typically, pull-requests are only fully reviewed when these tests are passing, though of course we can help out before then.
 
+## Changelog and release notes
+
+Release notes are drafted automatically from merged pull requests using GitHub labels.
+
+- Apply `bug`, `enhancement`, or `documentation` to have your PR included under the matching release notes section.
+- Apply `renovate-actions` for GitHub Actions and dependency-maintenance changes.
+- PRs without one of the release labels above are excluded from the automated changelog draft.
+- `CHANGELOG.md` is maintained at release time, so PR authors do not need to edit it for routine changes.
+
 ## Patch
 
 :warning: Only in the unlikely and regretful event of a release happening with a bug.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,5 +17,5 @@ Learn more about contributing: [CONTRIBUTING.md](https://github.com/seqeralabs/n
 - [ ] If plugin declarations changed, update `CITATIONS.md`, `README.md`, and agent/context guidance in the same PR.
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
 - [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
-- [ ] `CHANGELOG.md` is updated.
+- [ ] A release label (`bug`, `enhancement`, `documentation`, `renovate-actions`) is applied if this PR should appear in the automated changelog.
 - [ ] `README.md` is updated (including new tool citations and authors/contributors).

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,42 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+category-template: "### $TITLE"
+change-template: "- [PR #$NUMBER](https://github.com/seqeralabs/nf-aggregate/pull/$NUMBER) - $TITLE"
+change-title-escapes: "\\<*_&"
+no-changes-template: "- No user-facing changes."
+template: |
+  $CHANGES
+
+  ### Contributors
+
+  $CONTRIBUTORS
+categories:
+  - title: "Enhancements"
+    labels:
+      - "enhancement"
+  - title: "Fixes"
+    labels:
+      - "bug"
+  - title: "Documentation"
+    labels:
+      - "documentation"
+  - title: "Maintenance"
+    labels:
+      - "renovate-actions"
+exclude-labels:
+  - "duplicate"
+  - "invalid"
+  - "question"
+  - "wontfix"
+version-resolver:
+  minor:
+    labels:
+      - "enhancement"
+  patch:
+    labels:
+      - "bug"
+      - "documentation"
+      - "renovate-actions"
+  default: patch
+sort-by: "merged_at"
+sort-direction: "descending"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: "v$RESOLVED_VERSION"
-tag-template: "v$RESOLVED_VERSION"
+name-template: "$RESOLVED_VERSION"
+tag-template: "$RESOLVED_VERSION"
 category-template: "### $TITLE"
 change-template: "- [PR #$NUMBER](https://github.com/seqeralabs/nf-aggregate/pull/$NUMBER) - $TITLE"
 change-title-escapes: "\\<*_&"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,4 +20,4 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7.2.0
+      - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Update release draft
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - edited
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v7.2.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool, parameter, or workflow path, update the relevant docs.
- [ ] If plugin declarations changed, update `CITATIONS.md`, `README.md`, and agent/context guidance in the same PR.
- [x] Ensure the relevant validation checks pass for this GitHub automation change.
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] A release label (`bug`, `enhancement`, `documentation`, `renovate-actions`) is applied if this PR should appear in the automated changelog.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description

Issue #38 is still relevant on the current `main` branch: the repository still relied on manually updating `CHANGELOG.md` in the PR checklist and did not have any release-drafting workflow configured.

### Changes
- add `.github/release-drafter.yml` to generate release notes from the existing `bug`, `enhancement`, `documentation`, and `renovate-actions` labels
- add `.github/workflows/release-drafter.yml` to refresh the draft release on `main` pushes and PR metadata changes
- pin the new `release-drafter` action to the verified commit SHA required by policy
- update `.github/CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` to document the label-based changelog flow and remove the routine manual `CHANGELOG.md` expectation

### Validation
- parsed the workflow/config YAML with `PyYAML`
- ran `pre-commit` checks for the pinned workflow and the repo-wide changes successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eebb822-a9ed-438d-ada2-1db276000ccf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eebb822-a9ed-438d-ada2-1db276000ccf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

