### PR TITLE
📝 docs: document ARM64 (Apple Silicon) testing workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,25 @@ uv run --with typer --with pyyaml \
 - **nf-test (pipeline integration tests):** `nf-test test --profile=+docker --verbose`
 - **Lint:** `pre-commit run --all-files`
 
+### Running on Apple Silicon (ARM64)
+
+All pipeline containers are `linux/amd64` only (the Wave community image has no ARM64 variant). On ARM Macs, Docker runs these via QEMU/Rosetta emulation — tests and the pipeline work without any changes.
+
+For explicit x86_64 emulation (recommended on ARM Macs to avoid Docker platform-mismatch warnings), combine the `arm` profile with `docker`:
+
+```bash
+# nf-test
+nf-test test --profile=+docker,+arm --verbose
+
+# direct nextflow run
+nextflow run . --input workflows/nf_aggregate/assets/test_benchmark.csv \
+  --generate_benchmark_report --outdir results -profile docker,arm
+```
+
+The `arm` profile adds `--platform=linux/amd64` to Docker run options so the container engine picks the correct image manifest instead of silently falling back.
+
+Python unit tests (`pytest`) run natively on ARM — no `arm` profile needed for those.
+
 ### Agent quick verify (offline)
 
 Run this exact sequence when validating split benchmark-report changes in Cursor Cloud:


### PR DESCRIPTION
## Summary

- Pipeline containers are `linux/amd64`-only; on ARM Macs they run via QEMU/Rosetta emulation and all tests pass without changes
- Documents the existing `arm` Nextflow profile (`--platform=linux/amd64`) and when to use it explicitly to avoid Docker platform-mismatch warnings
- Python unit tests run natively on ARM and need no special profile

## Changes

- `AGENTS.md`: Added **"Running on Apple Silicon (ARM64)"** section with commands for `nf-test` and `nextflow run` using the `docker,arm` profile combination