### PR TITLE
feat: add include_failed_runs benchmark override

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ nextflow run seqeralabs/nf-aggregate \
 
 The benchmark report can be generated without cost data - simply omit the `--benchmark_aws_cur_report` parameter if cost analysis is not needed.
 
+If you want workflow-level failed runs to appear in downstream benchmark sections (run metrics, charts, task tables), pass `--include_failed_runs`. By default, failed workflows are listed in the run summary but excluded from downstream metrics. Cancelled workflows remain excluded.
+
 For a checked-in real-world example that exercises external run JSON directories plus a tiny filtered cost parquet, see:
 
 - `workflows/nf_aggregate/assets/test_benchmark_realworld_costs.csv`

--- a/bin/aggregate_benchmark_report_data.py
+++ b/bin/aggregate_benchmark_report_data.py
@@ -13,8 +13,17 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--jsonl-dir", type=Path, required=True, help="Directory containing JSONL bundle")
     parser.add_argument("--output", type=Path, default=Path("report_data.json"), help="Output report_data.json path")
+    parser.add_argument(
+        "--include-failed-runs",
+        action="store_true",
+        help="Include workflow-level failed runs in downstream report sections and charts",
+    )
     args = parser.parse_args(argv)
-    aggregate_report_data(jsonl_dir=args.jsonl_dir, output=args.output)
+    aggregate_report_data(
+        jsonl_dir=args.jsonl_dir,
+        output=args.output,
+        include_failed_runs=args.include_failed_runs,
+    )
     print(f"Report data written to {args.output}")
 
 

--- a/bin/benchmark_report.py
+++ b/bin/benchmark_report.py
@@ -40,11 +40,12 @@ def normalize_jsonl_cmd(
 def aggregate_report_data_cmd(
     jsonl_dir: Path = typer.Option(..., exists=True, help="Directory containing JSONL bundle"),
     output: Path = typer.Option(Path("report_data.json"), help="Output report_data.json path"),
+    include_failed_runs: bool = typer.Option(False, help="Include workflow-level failed runs in downstream report sections and charts"),
 ) -> None:
     """Aggregate JSONL bundle into report_data.json."""
     from benchmark_report_aggregate import aggregate_report_data
 
-    aggregate_report_data(jsonl_dir=jsonl_dir, output=output)
+    aggregate_report_data(jsonl_dir=jsonl_dir, output=output, include_failed_runs=include_failed_runs)
     typer.echo(f"Report data written to {output}")
 
 
@@ -69,12 +70,13 @@ def report(
     data_output: Path = typer.Option(Path("report_data.json"), help="Intermediate report_data.json output"),
     brand: Path = typer.Option(None, help="Brand YAML file"),
     logo: Path = typer.Option(None, help="SVG logo file"),
+    include_failed_runs: bool = typer.Option(False, help="Include workflow-level failed runs in downstream report sections and charts"),
 ) -> None:
     """Convenience wrapper: aggregate-report-data + render-html."""
     from benchmark_report_aggregate import aggregate_report_data
     from benchmark_report_render import render_report_from_json
 
-    aggregate_report_data(jsonl_dir=jsonl_dir, output=data_output)
+    aggregate_report_data(jsonl_dir=jsonl_dir, output=data_output, include_failed_runs=include_failed_runs)
     render_report_from_json(report_data_path=data_output, output=output, brand_path=brand, logo_path=logo)
     typer.echo(f"Report written to {output}")
 

--- a/modules/local/aggregate_benchmark_report_data/bin/benchmark_report_aggregate.py
+++ b/modules/local/aggregate_benchmark_report_data/bin/benchmark_report_aggregate.py
@@ -78,10 +78,10 @@ def _is_highlight_process(process: str) -> bool:
     return any(keyword in process_lc for keyword in _HIGHLIGHT_KEYWORDS)
 
 
-def _classify_workflow_status(status: str | None) -> tuple[str, str, bool]:
+def _classify_workflow_status(status: str | None, include_failed_runs: bool = False) -> tuple[str, str, bool]:
     normalized = (status or "").strip().upper()
     if normalized in {"FAILED", "ERROR", "FAILING"}:
-        return ("Failed", "failed", False)
+        return ("Failed", "failed", include_failed_runs)
     if normalized in {"CANCELLED", "CANCELED", "ABORTED", "ABORT", "STOPPED"}:
         return ("Cancelled", "cancelled", False)
     if normalized in {"SUCCEEDED", "SUCCESS", "COMPLETED"}:
@@ -135,7 +135,7 @@ def _load_machines_index(jsonl_dir: Path) -> dict[str, dict[str, Any]]:
     return index
 
 
-def build_report_data(jsonl_dir: Path) -> dict[str, Any]:
+def build_report_data(jsonl_dir: Path, include_failed_runs: bool = False) -> dict[str, Any]:
     benchmark_overview: list[dict[str, Any]] = []
     run_summary: list[dict[str, Any]] = []
     run_metrics: list[dict[str, Any]] = []
@@ -149,7 +149,9 @@ def build_report_data(jsonl_dir: Path) -> dict[str, Any]:
         run_id = str(r.get("run_id", ""))
         group = str(r.get("group", ""))
         run_pipeline[run_id] = str(r.get("pipeline") or "unknown")
-        status_label, status_category, report_included = _classify_workflow_status(r.get("status"))
+        status_label, status_category, report_included = _classify_workflow_status(
+            r.get("status"), include_failed_runs=include_failed_runs
+        )
 
         benchmark_overview.append(
             {
@@ -601,6 +603,6 @@ def build_report_data(jsonl_dir: Path) -> dict[str, Any]:
     }
 
 
-def aggregate_report_data(jsonl_dir: Path, output: Path) -> None:
-    data = build_report_data(jsonl_dir)
+def aggregate_report_data(jsonl_dir: Path, output: Path, include_failed_runs: bool = False) -> None:
+    data = build_report_data(jsonl_dir, include_failed_runs=include_failed_runs)
     output.write_text(json.dumps(data, default=str))

--- a/modules/local/aggregate_benchmark_report_data/main.nf
+++ b/modules/local/aggregate_benchmark_report_data/main.nf
@@ -5,15 +5,18 @@ process AGGREGATE_BENCHMARK_REPORT_DATA {
 
     input:
     path jsonl_bundle
+    val include_failed_runs
 
     output:
     path "report_data.json", emit: data
     path "versions.yml",     emit: versions
 
     script:
+    include_failed_runs_arg = include_failed_runs ? '--include-failed-runs' : ''
     """
     aggregate_benchmark_report_data.py \\
         --jsonl-dir ${jsonl_bundle} \\
+        ${include_failed_runs_arg} \\
         --output report_data.json
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py
+++ b/modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py
@@ -148,6 +148,38 @@ def test_failed_and_cancelled_runs_only_appear_in_overview(tmp_path, make_run, f
     assert {row["run_id"] for row in data["task_scatter"]} == {"run-success"}
 
 
+def test_include_failed_runs_override_includes_failed_in_downstream_sections(tmp_path, make_run, flat_task, write_run_json):
+    data_dir = tmp_path / "data"
+    jsonl_dir = tmp_path / "jsonl_bundle"
+    write_run_json(
+        data_dir,
+        [
+            make_run(run_id="run-success", group="cpu", tasks=[flat_task()]),
+            make_run(run_id="run-failed", group="gpu", tasks=[flat_task()], status="FAILED"),
+            make_run(run_id="run-cancelled", group="spot", tasks=[flat_task()], status="CANCELLED"),
+        ],
+    )
+    normalize_jsonl(data_dir, jsonl_dir)
+
+    data = build_report_data(jsonl_dir, include_failed_runs=True)
+
+    overview = {row["run_id"]: row for row in data["benchmark_overview"]}
+    assert overview["run-success"]["report_included"] is True
+    assert overview["run-failed"]["report_included"] is True
+    assert overview["run-failed"]["status_category"] == "failed"
+    assert overview["run-cancelled"]["report_included"] is False
+
+    summary = {row["run_id"]: row for row in data["run_summary"]}
+    assert summary["run-success"]["report_included"] is True
+    assert summary["run-failed"]["report_included"] is True
+    assert summary["run-cancelled"]["report_included"] is False
+
+    assert [row["run_id"] for row in data["run_metrics"]] == ["run-success", "run-failed"]
+    assert [row["run_id"] for row in data["run_costs"]] == ["run-success", "run-failed"]
+    assert {row["Run ID"] for row in data["task_table"]} == {"run-success", "run-failed"}
+    assert {row["run_id"] for row in data["task_scatter"]} == {"run-success", "run-failed"}
+
+
 def test_iter_jsonl_is_lazy(tmp_path):
     path = tmp_path / "rows.jsonl"
     path.write_text('{"ok": 1}\nnot-json\n')

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,6 +20,7 @@ params {
     // Benchmark report options
     generate_benchmark_report    = false
     benchmark_aws_cur_report     = null
+    include_failed_runs          = false
 
     // Boilerplate options
     outdir                       = 'results'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -67,6 +67,12 @@
                     "description": "AWS CUR report from data exports.",
                     "pattern": "^\\S+\\.parquet",
                     "format": "file-path"
+                },
+                "include_failed_runs": {
+                    "type": "boolean",
+                    "default": false,
+                    "fa_icon": "fas fa-exclamation-triangle",
+                    "description": "Include workflow-level failed runs in downstream benchmark sections and charts. Cancelled workflows remain excluded."
                 }
             },
             "required": ["seqera_api_endpoint"]

--- a/workflows/nf_aggregate/main.nf
+++ b/workflows/nf_aggregate/main.nf
@@ -152,6 +152,7 @@ workflow NF_AGGREGATE {
 
         AGGREGATE_BENCHMARK_REPORT_DATA(
             NORMALIZE_BENCHMARK_JSONL.out.jsonl,
+            params.include_failed_runs,
         )
         ch_versions = ch_versions.mix(AGGREGATE_BENCHMARK_REPORT_DATA.out.versions)
 


### PR DESCRIPTION
## Summary
- add an `include_failed_runs` / `include-failed-runs` override for benchmark report generation
- keep the current default behavior unchanged: failed workflows remain excluded unless the flag is set
- continue excluding cancelled workflows
- plumb the flag through the Python CLIs, Nextflow params, schema, and workflow wiring
- add regression coverage for the new override behavior

## Why
When comparing benchmark runs, it is useful to inspect workflow-level failed runs in the downstream HTML sections and charts instead of only seeing them dimmed/excluded in the run summary.

## Test plan
- `UV_NO_CONFIG=1 uv run --with typer --with pyyaml --with jinja2 --with pyarrow --with pytest --with httpx pytest -q modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py::test_failed_and_cancelled_runs_only_appear_in_overview modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py::test_include_failed_runs_override_includes_failed_in_downstream_sections`
- `UV_NO_CONFIG=1 uv run --with typer --with pyyaml --with jinja2 --with pyarrow --with pytest --with httpx pytest -q modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py modules/local/render_benchmark_report/tests/test_render.py`
- regenerated a local HTML report with failed runs included and verified the failed run IDs appear in downstream sections

## Notes
- this change does not address the separate latest-main regressions around raw `tw runs dump` tarballs or the aggregate-stage symlink/import issue
- this PR focuses only on the include-failed-runs override
