### PR TITLE
fix(benchmark-report): hide unavailable split-cost breakdown

### DIFF
--- a/bin/benchmark_report_aggregate.py
+++ b/bin/benchmark_report_aggregate.py
@@ -258,6 +258,7 @@ def build_report_data(jsonl_dir: Path, include_failed_runs: bool = False) -> dic
             "cost": 0.0,
             "used_cost": 0.0,
             "unused_cost": 0.0,
+            "split_cost_present": False,
         }
 
     costs_jsonl_path = jsonl_dir / "costs.jsonl"
@@ -276,11 +277,14 @@ def build_report_data(jsonl_dir: Path, include_failed_runs: bool = False) -> dic
                 "cost": 0.0,
                 "used_cost": 0.0,
                 "unused_cost": 0.0,
+                "split_cost_present": False,
             }
 
         costs_index[key]["cost"] += float(c.get("cost") or 0.0)
         costs_index[key]["used_cost"] += float(c.get("used_cost") or 0.0)
         costs_index[key]["unused_cost"] += float(c.get("unused_cost") or 0.0)
+        if c.get("split_cost_present"):
+            costs_index[key]["split_cost_present"] = True
 
     process_acc: dict[tuple[str, str, str], dict[str, float | int | str]] = defaultdict(
         lambda: {
@@ -334,6 +338,7 @@ def build_report_data(jsonl_dir: Path, include_failed_runs: bool = False) -> dic
                 "cost": 0.0,
                 "used_cost": 0.0,
                 "unused_cost": 0.0,
+                "split_cost_present": False,
             }
 
         cost_row = _lookup_cost(costs_index, run_id=run_id, process=process, process_short=process_short, hash_short=hash_short)
@@ -365,6 +370,8 @@ def build_report_data(jsonl_dir: Path, include_failed_runs: bool = False) -> dic
             run_cost_acc[run_group_key]["cost"] += _cost_or_task(cost_row, "cost")
             run_cost_acc[run_group_key]["used_cost"] += _cost_or_task(cost_row, "used_cost")
             run_cost_acc[run_group_key]["unused_cost"] += _cost_or_task(cost_row, "unused_cost")
+            if cost_row.get("split_cost_present"):
+                run_cost_acc[run_group_key]["split_cost_present"] = True
 
         if has_cost_rows:
             overview_key = (group, process_short)
@@ -518,8 +525,9 @@ def build_report_data(jsonl_dir: Path, include_failed_runs: bool = False) -> dic
                 "run_id": row["run_id"],
                 "group": row["group"],
                 "cost": _round(row["cost"], 2),
-                "used_cost": _round(row["used_cost"], 2) if has_cost_rows else None,
-                "unused_cost": _round(row["unused_cost"], 2) if has_cost_rows else None,
+                "used_cost": _round(row["used_cost"], 2) if has_cost_rows and row.get("split_cost_present") else None,
+                "unused_cost": _round(row["unused_cost"], 2) if has_cost_rows and row.get("split_cost_present") else None,
+                "split_cost_present": bool(row.get("split_cost_present")),
             }
             for row in run_cost_acc.values()
         ],

--- a/bin/benchmark_report_normalize.py
+++ b/bin/benchmark_report_normalize.py
@@ -400,7 +400,8 @@ def _normalize_cost_rows(costs_parquet: Path, cost_label_map: Path | None = None
             substr(COALESCE({task_hash_expr}, ''), 1, 8)  AS hash,
             SUM(({used_cost}) + ({unused_cost}))          AS cost,
             SUM({used_cost})                              AS used_cost,
-            SUM({unused_cost})                            AS unused_cost
+            SUM({unused_cost})                            AS unused_cost,
+            MAX(CASE WHEN {split_cost} <> 0 OR {unused_cost} <> 0 THEN 1 ELSE 0 END) AS split_cost_present
         FROM {scan}
         WHERE {run_id_expr} IS NOT NULL AND {run_id_expr} <> ''
         GROUP BY 1, 2, 3

--- a/modules/local/aggregate_benchmark_report_data/bin/benchmark_report_aggregate.py
+++ b/modules/local/aggregate_benchmark_report_data/bin/benchmark_report_aggregate.py
@@ -258,6 +258,7 @@ def build_report_data(jsonl_dir: Path, include_failed_runs: bool = False) -> dic
             "cost": 0.0,
             "used_cost": 0.0,
             "unused_cost": 0.0,
+            "split_cost_present": False,
         }
 
     costs_jsonl_path = jsonl_dir / "costs.jsonl"
@@ -276,11 +277,14 @@ def build_report_data(jsonl_dir: Path, include_failed_runs: bool = False) -> dic
                 "cost": 0.0,
                 "used_cost": 0.0,
                 "unused_cost": 0.0,
+                "split_cost_present": False,
             }
 
         costs_index[key]["cost"] += float(c.get("cost") or 0.0)
         costs_index[key]["used_cost"] += float(c.get("used_cost") or 0.0)
         costs_index[key]["unused_cost"] += float(c.get("unused_cost") or 0.0)
+        if c.get("split_cost_present"):
+            costs_index[key]["split_cost_present"] = True
 
     process_acc: dict[tuple[str, str, str], dict[str, float | int | str]] = defaultdict(
         lambda: {
@@ -334,6 +338,7 @@ def build_report_data(jsonl_dir: Path, include_failed_runs: bool = False) -> dic
                 "cost": 0.0,
                 "used_cost": 0.0,
                 "unused_cost": 0.0,
+                "split_cost_present": False,
             }
 
         cost_row = _lookup_cost(costs_index, run_id=run_id, process=process, process_short=process_short, hash_short=hash_short)
@@ -365,6 +370,8 @@ def build_report_data(jsonl_dir: Path, include_failed_runs: bool = False) -> dic
             run_cost_acc[run_group_key]["cost"] += _cost_or_task(cost_row, "cost")
             run_cost_acc[run_group_key]["used_cost"] += _cost_or_task(cost_row, "used_cost")
             run_cost_acc[run_group_key]["unused_cost"] += _cost_or_task(cost_row, "unused_cost")
+            if cost_row.get("split_cost_present"):
+                run_cost_acc[run_group_key]["split_cost_present"] = True
 
         if has_cost_rows:
             overview_key = (group, process_short)
@@ -518,8 +525,9 @@ def build_report_data(jsonl_dir: Path, include_failed_runs: bool = False) -> dic
                 "run_id": row["run_id"],
                 "group": row["group"],
                 "cost": _round(row["cost"], 2),
-                "used_cost": _round(row["used_cost"], 2) if has_cost_rows else None,
-                "unused_cost": _round(row["unused_cost"], 2) if has_cost_rows else None,
+                "used_cost": _round(row["used_cost"], 2) if has_cost_rows and row.get("split_cost_present") else None,
+                "unused_cost": _round(row["unused_cost"], 2) if has_cost_rows and row.get("split_cost_present") else None,
+                "split_cost_present": bool(row.get("split_cost_present")),
             }
             for row in run_cost_acc.values()
         ],

--- a/modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py
+++ b/modules/local/aggregate_benchmark_report_data/tests/test_aggregate.py
@@ -107,8 +107,8 @@ def test_cur_zero_costs_do_not_fall_back_to_task_cost(tmp_path):
     data = build_report_data(jsonl_dir)
 
     assert data["run_costs"][0]["cost"] == 0.0
-    assert data["run_costs"][0]["used_cost"] == 0.0
-    assert data["run_costs"][0]["unused_cost"] == 0.0
+    assert data["run_costs"][0]["used_cost"] is None
+    assert data["run_costs"][0]["unused_cost"] is None
     assert data["cost_overview"][0]["total_cost"] == 0.0
     assert data["cost_overview"][0]["used_cost"] == 0.0
     assert data["cost_coverage"]["cur_supplied"] is True
@@ -357,8 +357,8 @@ def test_cost_join_uses_process_and_hash(tmp_path):
         },
     ]
     costs = [
-        {"run_id": "run1", "process": "foo:PROC_A", "hash": "abcdef12", "cost": 5.0, "used_cost": 4.0, "unused_cost": 1.0},
-        {"run_id": "run1", "process": "foo:PROC_B", "hash": "abcdef12", "cost": 7.0, "used_cost": 6.0, "unused_cost": 1.0},
+        {"run_id": "run1", "process": "foo:PROC_A", "hash": "abcdef12", "cost": 5.0, "used_cost": 4.0, "unused_cost": 1.0, "split_cost_present": True},
+        {"run_id": "run1", "process": "foo:PROC_B", "hash": "abcdef12", "cost": 7.0, "used_cost": 6.0, "unused_cost": 1.0, "split_cost_present": True},
     ]
 
     (jsonl_dir / "runs.jsonl").write_text("".join(json.dumps(r) + "\n" for r in runs))

--- a/modules/local/normalize_benchmark_jsonl/bin/benchmark_report_normalize.py
+++ b/modules/local/normalize_benchmark_jsonl/bin/benchmark_report_normalize.py
@@ -400,7 +400,8 @@ def _normalize_cost_rows(costs_parquet: Path, cost_label_map: Path | None = None
             substr(COALESCE({task_hash_expr}, ''), 1, 8)  AS hash,
             SUM(({used_cost}) + ({unused_cost}))          AS cost,
             SUM({used_cost})                              AS used_cost,
-            SUM({unused_cost})                            AS unused_cost
+            SUM({unused_cost})                            AS unused_cost,
+            MAX(CASE WHEN {split_cost} <> 0 OR {unused_cost} <> 0 THEN 1 ELSE 0 END) AS split_cost_present
         FROM {scan}
         WHERE {run_id_expr} IS NOT NULL AND {run_id_expr} <> ''
         GROUP BY 1, 2, 3

--- a/modules/local/normalize_benchmark_jsonl/tests/test_normalize.py
+++ b/modules/local/normalize_benchmark_jsonl/tests/test_normalize.py
@@ -112,6 +112,7 @@ def test_normalize_cost_rows_reads_parquet_in_batches(tmp_path):
             "cost": 5.0,
             "used_cost": 4.0,
             "unused_cost": 1.0,
+            "split_cost_present": True,
         }
     ]
 
@@ -148,6 +149,7 @@ def test_normalize_cost_rows_accepts_custom_flat_aliases(tmp_path):
             "cost": 3.75,
             "used_cost": 3.0,
             "unused_cost": 0.75,
+            "split_cost_present": True,
         }
     ]
 
@@ -185,6 +187,7 @@ def test_normalize_cost_rows_accepts_custom_resource_tag_aliases(tmp_path):
             "cost": 3.0,
             "used_cost": 2.5,
             "unused_cost": 0.5,
+            "split_cost_present": True,
         }
     ]
 
@@ -221,6 +224,7 @@ def test_normalize_cost_rows_accepts_v2_struct_list_resource_tags(tmp_path):
             "cost": 4.0,
             "used_cost": 4.0,
             "unused_cost": 0.0,
+            "split_cost_present": False,
         }
     ]
 
@@ -260,6 +264,7 @@ def test_normalize_cost_rows_accepts_map_resource_tags(tmp_path):
             "cost": 7.0,
             "used_cost": 7.0,
             "unused_cost": 0.0,
+            "split_cost_present": False,
         }
     ]
 
@@ -323,6 +328,7 @@ def test_normalize_cost_rows_reads_directory_of_parquets(tmp_path):
             "cost": 3.0,
             "used_cost": 3.0,
             "unused_cost": 0.0,
+            "split_cost_present": True,
         }
     ]
 
@@ -352,6 +358,7 @@ def test_normalize_cost_rows_ignores_rows_without_run_label(tmp_path):
             "cost": 1.0,
             "used_cost": 1.0,
             "unused_cost": 0.0,
+            "split_cost_present": True,
         }
     ]
 


### PR DESCRIPTION
> Stacked on `feature/intelligent-compute-report`. Merge the parent branch first.

## Summary
- record whether CUR rows contain genuine ECS split cost allocation
- propagate that signal through report aggregation per run
- render unavailable used/unused costs as em dashes instead of duplicating blended cost and showing `$0.00`
- keep top-level and module script copies synchronized

## Verification
- `79 passed` (`pytest -q`)
- normalize and aggregate script copies are byte-identical